### PR TITLE
Add the constant 'GTMKIT_WC_DEBUG_TRACK_PURCHASE'

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,7 @@ Yes! Pagespeed is one of our main focus points, and we strive to make the plugin
 
 Enhancements:
 
+* Added the constant 'GTMKIT_WC_DEBUG_TRACK_PURCHASE', which allows you to force tracking of purchase event on every page refresh for debugging.
 
 Bugfixes:
 

--- a/src/Integration/WooCommerce.php
+++ b/src/Integration/WooCommerce.php
@@ -394,8 +394,10 @@ class WooCommerce  extends AbstractEcommerce {
 				return $data_layer;
 			}
 
-			if ( ( 1 === (int) $order->get_meta('_gtmkit_order_tracked') ) ) {
-				return $data_layer;
+			if ( ( 1 === (int) $order->get_meta( '_gtmkit_order_tracked' ) ) ) {
+				if ( ! ( $this->options->is_const_enabled() && $this->options->is_const_defined( 'integration', 'woocommerce_always_track_purchase' ) ) ) {
+					return $data_layer;
+				}
 			}
 		} else {
 			return $data_layer;


### PR DESCRIPTION
The constant 'GTMKIT_WC_DEBUG_TRACK_PURCHASE' allows you to force tracking of purchase event on every page refresh for debugging.