### PR TITLE
Cast transaction_id to string

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,8 @@ Enhancements:
 
 Bugfixes:
 
+* Cast transaction_id to string. According to the GA4 documentation transaction_id should be a string as it allows numbers, letters, and special characters like dashes or spaces.
+
 Other:
 
 = 1.11 =

--- a/src/Integration/EasyDigitalDownloads.php
+++ b/src/Integration/EasyDigitalDownloads.php
@@ -291,7 +291,7 @@ final class EasyDigitalDownloads extends AbstractEcommerce {
 
 		$data_layer['event']     = 'purchase';
 		$data_layer['ecommerce'] = [
-			'transaction_id' => (int) $order->get_number(),
+			'transaction_id' => (string) $order->get_number(),
 			'value'          => (float) $order_value,
 			'tax'            => (float) $order->tax,
 			'currency'       => $order->currency,

--- a/src/Integration/WooCommerce.php
+++ b/src/Integration/WooCommerce.php
@@ -453,7 +453,7 @@ final class WooCommerce  extends AbstractEcommerce {
 
 		$data_layer['event']     = 'purchase';
 		$data_layer['ecommerce'] = [
-			'transaction_id' => (int) $order->get_order_number(),
+			'transaction_id' => (string) $order->get_order_number(),
 			'value'          => (float) $order_value,
 			'tax'            => (float) $order->get_total_tax(),
 			'shipping'       => (float) $shipping_total,


### PR DESCRIPTION
According to the GA4 documentatin transaction_id should be a string as it allows numbers, letters, and special characters like dashes or spaces.