### PR TITLE
Consolidate wp-admin plugin.php loading into Util::load_plugin_api()

### DIFF
--- a/src/Common/Util.php
+++ b/src/Common/Util.php
@@ -226,10 +226,7 @@ final class Util {
 	 */
 	public function get_active_plugins(): array {
 
-		if ( ! function_exists( 'get_plugins' ) ) {
-			// @phpstan-ignore-next-line requireOnce.fileNotFound -- ABSPATH is defined by WordPress at runtime; path is not statically resolvable.
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
+		self::load_plugin_api();
 
 		$plugins        = [];
 		$active_plugins = array_intersect_key( \get_plugins(), array_flip( array_filter( array_keys( \get_plugins() ), 'is_plugin_active' ) ) );
@@ -508,5 +505,24 @@ final class Util {
 	 */
 	private function get_admin_url(): string {
 		return is_network_admin() ? network_admin_url() : admin_url();
+	}
+
+	/**
+	 * Ensure WordPress' admin-side plugin API (`is_plugin_active()`, `get_plugins()`, etc.)
+	 * is loaded.
+	 *
+	 * WordPress loads `wp-admin/includes/plugin.php` automatically on admin requests but not
+	 * on the frontend, REST, or AJAX. Any non-admin code path that calls `is_plugin_active()`
+	 * or `get_plugins()` must require the file first. Centralised here so the single
+	 * `requireOnce.fileNotFound` suppression lives in one place rather than being duplicated
+	 * at every call site.
+	 *
+	 * @return void
+	 */
+	public static function load_plugin_api(): void {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			// @phpstan-ignore-next-line requireOnce.fileNotFound -- ABSPATH is defined by WordPress at runtime; path is not statically resolvable.
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
 	}
 }

--- a/src/Installation/PluginDataImport.php
+++ b/src/Installation/PluginDataImport.php
@@ -7,6 +7,8 @@
 
 namespace TLA_Media\GTM_Kit\Installation;
 
+use TLA_Media\GTM_Kit\Common\Util;
+
 /**
  * Class for preparing import data from other GTM plugins.
  */
@@ -232,11 +234,7 @@ class PluginDataImport {
 	 * @return bool
 	 */
 	private function is_plugin_active( string $plugin ): bool {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			// @phpstan-ignore-next-line requireOnce.fileNotFound -- ABSPATH is defined by WordPress at runtime; path is not statically resolvable.
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-		}
+		Util::load_plugin_api();
 
 		return \is_plugin_active( $plugin );
 	}

--- a/src/Options/OptionSchema.php
+++ b/src/Options/OptionSchema.php
@@ -7,6 +7,8 @@
 
 namespace TLA_Media\GTM_Kit\Options;
 
+use TLA_Media\GTM_Kit\Common\Util;
+
 /**
  * Option Schema - Defines validation rules, types, and defaults
  *
@@ -145,10 +147,7 @@ final class OptionSchema {
 		];
 
 		// Dynamic options based on active plugins.
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			// @phpstan-ignore-next-line requireOnce.fileNotFound -- ABSPATH is defined by WordPress at runtime; path is not statically resolvable.
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
+		Util::load_plugin_api();
 
 		if ( \is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
 			$schema['woocommerce_integration'] = [


### PR DESCRIPTION
Three classes used the same "maybe require_once ABSPATH . 'wp-admin/includes/plugin.php'" idiom, each carrying its own @phpstan-ignore-next-line requireOnce.fileNotFound. Extract a single Util::load_plugin_api() static helper that owns the load and the one remaining suppression. The three callers become one-liners, and future non-admin code paths that need `is_plugin_active()` / `get_plugins()` have a documented place to hook in.

No behavior change — same guarded require, same runtime effect. PHPStan, PHPCS, and the unit + integration suites are all green.