### PR TITLE
Announce the new internal test harness and CI matrix in the changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** GTM Kit ***
 
+Unreleased
+* Dev: Introduced an internal automated test suite (PHPUnit + Vitest) and continuous integration across PHP 7.4–8.4 × WordPress 6.9. No functional change — every future release is now verified by unit and integration tests before shipping, raising the bar on quality and reliability.
+
 2026-04-23 - version 2.8.4
 * Dev: Declared compatibility with WooCommerce Product Object Caching (`product_instance_caching`) introduced in WooCommerce 10.5. No functional change; resolves the "incompatible plugins" notice in WooCommerce → Settings → Advanced → Features.
 * Dev: Tested up to WooCommerce 10.7.

--- a/readme.txt
+++ b/readme.txt
@@ -96,7 +96,12 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= 2.8.3 =
+= Unreleased =
+
+#### Other:
+* Introduced an internal automated test suite (PHPUnit + Vitest) and continuous integration across PHP 7.4–8.4 × WordPress 6.9. No functional change — every future release is now verified by unit and integration tests before shipping, raising the bar on quality and reliability.
+
+= 2.8.4 =
 
 Release date: 2026-04-23
 


### PR DESCRIPTION
Marketing-facing note filed under "Unreleased" — no release is imminent. No shipped code change; the PHPUnit + Vitest suites and the PHP 7.4–8.4 × WP 6.9 GitHub Actions matrix strengthen quality assurance, which is worth surfacing to users evaluating the plugin.

Also corrects a pre-existing readme.txt typo: the 2026-04-23 entry was mislabelled `= 2.8.3 =`; it is version 2.8.4 per changelog.txt.