### PR TITLE
Skip the CI test matrix on documentation-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,36 @@
 name: Tests
 
+# Skip the matrix when a change cannot possibly affect test outcomes —
+# Markdown, changelog/readme text, translations, LICENSE, editor/dist
+# config, built assets, and the release zip. Anything else (PHP, JS,
+# composer/npm manifests, the workflow file itself, etc.) still runs
+# the full matrix.
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+      - '**/*.pot'
+      - 'LICENSE'
+      - '.editorconfig'
+      - '.distignore'
+      - '.gitignore'
+      - 'languages/**'
+      - 'assets/**'
+      - 'bundled/**'
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+      - '**/*.pot'
+      - 'LICENSE'
+      - '.editorconfig'
+      - '.distignore'
+      - '.gitignore'
+      - 'languages/**'
+      - 'assets/**'
+      - 'bundled/**'
 
 jobs:
   test:


### PR DESCRIPTION
Commits that only touch Markdown, changelog/readme text, translations, LICENSE, or editor/dist config cannot affect test outcomes — but were triggering the full PHP 7.4–8.4 × WP 6.9 matrix (five jobs + MySQL service + WP checkout per run). Add paths-ignore to both the pull_request and push triggers so those runs are suppressed.

Anything else (PHP, JS, composer/npm manifests, the workflow file itself, tests/**) still runs the matrix. Mixed PRs that include any code change also still run — paths-ignore only skips when every changed file matches.