### PR TITLE
Fix: register gtmkit-container before dependent scripts at lower priority

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** GTM Kit ***
 
+Unreleased
+* Fix: Eliminate "dependencies that are not registered: gtmkit-container" warnings logged by WordPress 6.9.1+ on sites that have GTM Kit's container active.
+
 2026-04-29 - version 2.9.0
 * Add: Scope Google Consent Mode defaults to specific countries or regions (e.g. DK, DE, US-CA) instead of applying them everywhere. Useful for sites with visitors both inside and outside the EU.
 * Add: Consent updates from other plugins or partner scripts can now talk to GTM Kit through a simple JavaScript API, making CMP integrations easier.

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,11 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= Unreleased =
+
+#### Bugfixes:
+* Eliminate "dependencies that are not registered: gtmkit-container" warnings logged by WordPress 6.9.1+ on sites that have GTM Kit's container active.
+
 = 2.9.0 =
 
 Release date: 2026-04-29

--- a/src/Frontend/Frontend.php
+++ b/src/Frontend/Frontend.php
@@ -54,7 +54,8 @@ final class Frontend {
 		}
 
 		if ( $container_active && $page->is_user_allowed() ) {
-			add_action( 'wp_enqueue_scripts', [ $page, 'enqueue_header_script' ] );
+			// Priority 6 so 'gtmkit-container' is registered before any dependent script (WP 6.9.1 validates deps at enqueue time).
+			add_action( 'wp_enqueue_scripts', [ $page, 'enqueue_header_script' ], 6 );
 		} elseif ( $options->get( 'general', 'console_log' ) ) {
 			add_action( 'wp_head', [ $page, 'container_disabled' ] );
 		}


### PR DESCRIPTION
WP 6.9.1 added a soft-validation warning that fires when a script is enqueued with deps that are not yet registered.

Lower the priority on enqueue_header_script to 6 so gtmkit-container is registered before any priority-10 dependent runs.