### PR TITLE
Add: Consent signal source registry and event deferral gate

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 *** GTM Kit ***
 
 Unreleased
+* Add: New developer hooks let CMP integrations and consent add-ons plug into GTM Kit's consent flow without forking the plugin — sites running Cookiebot, CookieYes, WP Consent API or in-house consent solutions can now feed their state straight into GTM Kit.
+* Add: Server-side broadcast `gtmkit_consent_updated` so other plugins can react to consent state changes without polling.
+* Add: Per-event `gtmkit_event_should_defer` filter so future deferral features can hold individual events back when consent is missing.
 * Fix: Eliminate "dependencies that are not registered: gtmkit-container" warnings logged by WordPress 6.9.1+ on sites that have GTM Kit's container active.
 
 2026-04-29 - version 2.9.0

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,11 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = Unreleased =
 
+#### New:
+* New developer hooks let CMP integrations and consent add-ons plug into GTM Kit's consent flow without forking the plugin — sites running Cookiebot, CookieYes, WP Consent API or in-house consent solutions can now feed their state straight into GTM Kit.
+* Server-side broadcast `gtmkit_consent_updated` so other plugins can react to consent state changes without polling.
+* Per-event `gtmkit_event_should_defer` filter so future deferral features can hold individual events back when consent is missing.
+
 #### Bugfixes:
 * Eliminate "dependencies that are not registered: gtmkit-container" warnings logged by WordPress 6.9.1+ on sites that have GTM Kit's container active.
 

--- a/src/Frontend/ConsentSignalSourceRegistry.php
+++ b/src/Frontend/ConsentSignalSourceRegistry.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * GTM Kit plugin file.
+ *
+ * @package GTM Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Frontend;
+
+use TLA_Media\GTM_Kit\Options\Options;
+
+/**
+ * Consent signal source registry.
+ *
+ * Encapsulates registration and resolution of consent signal sources.
+ * The registry exposes a single filter (`gtmkit_consent_signal_sources`)
+ * that lets Premium add-ons and third-party code plug in alternative
+ * consent state providers (e.g., wp-consent-api, CMPs) without
+ * modifying core. The highest-priority active source wins; the
+ * default source falls back to the Consent Mode v2 settings emitted
+ * by the existing admin toggles.
+ *
+ * Priority registry (documented for ecosystem coordination):
+ *
+ *  - `gtmkit_default`  priority  10 (this class, core fallback)
+ *  - CMPs              priority  80 (reserved for CMP integrations)
+ *  - `wp_consent_api`  priority 100 (reserved for WP Consent API integration)
+ *
+ * Source descriptor shape (the array returned through the filter):
+ *
+ *     [
+ *         'gtmkit_default' => [
+ *             'id'        => 'gtmkit_default',
+ *             'priority'  => 10,
+ *             'is_active' => callable(): bool,
+ *             'read'      => callable(): array<string, 'granted'|'denied'>,
+ *         ],
+ *     ]
+ */
+final class ConsentSignalSourceRegistry {
+
+	/**
+	 * Default-source identifier.
+	 *
+	 * @var string
+	 */
+	public const DEFAULT_SOURCE_ID = 'gtmkit_default';
+
+	/**
+	 * Default-source priority. Documented in `docs/filters.md` so
+	 * third parties can decide whether to override (priority > 10)
+	 * or sit below (priority < 10).
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_SOURCE_PRIORITY = 10;
+
+	/**
+	 * The seven Consent Mode v2 categories, in the canonical order
+	 * used by the rest of GTM Kit (see Frontend::enqueue_settings_and_data_script()).
+	 *
+	 * @var array<int, string>
+	 */
+	private const CATEGORIES = [
+		'ad_personalization',
+		'ad_storage',
+		'ad_user_data',
+		'analytics_storage',
+		'personalization_storage',
+		'functionality_storage',
+		'security_storage',
+	];
+
+	/**
+	 * Plugin options.
+	 *
+	 * @var Options
+	 */
+	private Options $options;
+
+	/**
+	 * Constructor.
+	 *
+	 * Registers the default `gtmkit_default` signal source on the
+	 * `gtmkit_consent_signal_sources` filter at priority 1, so user
+	 * code at the default WordPress filter priority (10) can override
+	 * or remove it via the same filter.
+	 *
+	 * @param Options $options An instance of Options.
+	 */
+	public function __construct( Options $options ) {
+		$this->options = $options;
+
+		// add_filter dedupes [object, method] callbacks per spl_object_hash,
+		// so re-constructing the registry within a single request is safe.
+		add_filter( 'gtmkit_consent_signal_sources', [ $this, 'register_default_source' ], 1 );
+	}
+
+	/**
+	 * Hook callback: register the default signal source.
+	 *
+	 * Wraps the existing legacy filters so the legacy path keeps working
+	 * when no override source is registered:
+	 *
+	 *  - `is_active` returns the result of `gtmkit_consent_default_settings_enabled`.
+	 *  - `read`      returns the result of `gtmkit_consent_default_state`.
+	 *
+	 * @param mixed $sources Registry passed through the filter chain.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function register_default_source( $sources ): array {
+		if ( ! is_array( $sources ) ) {
+			$sources = [];
+		}
+
+		$options = $this->options;
+
+		$sources[ self::DEFAULT_SOURCE_ID ] = [
+			'id'        => self::DEFAULT_SOURCE_ID,
+			'priority'  => self::DEFAULT_SOURCE_PRIORITY,
+			'is_active' => static function () use ( $options ): bool {
+				return (bool) apply_filters(
+					'gtmkit_consent_default_settings_enabled',
+					(bool) $options->get( 'general', 'gcm_default_settings' )
+				);
+			},
+			'read'      => static function () use ( $options ): array {
+				/**
+				 * Per-category Consent Mode v2 default state.
+				 *
+				 * @param array<string, 'granted'|'denied'> $consent_defaults The seven-category state.
+				 */
+				$consent_defaults = apply_filters(
+					'gtmkit_consent_default_state',
+					[
+						'ad_personalization'      => $options->get( 'general', 'gcm_ad_personalization' ) ? 'granted' : 'denied',
+						'ad_storage'              => $options->get( 'general', 'gcm_ad_storage' ) ? 'granted' : 'denied',
+						'ad_user_data'            => $options->get( 'general', 'gcm_ad_user_data' ) ? 'granted' : 'denied',
+						'analytics_storage'       => $options->get( 'general', 'gcm_analytics_storage' ) ? 'granted' : 'denied',
+						'personalization_storage' => $options->get( 'general', 'gcm_personalization_storage' ) ? 'granted' : 'denied',
+						'functionality_storage'   => $options->get( 'general', 'gcm_functionality_storage' ) ? 'granted' : 'denied',
+						'security_storage'        => $options->get( 'general', 'gcm_security_storage' ) ? 'granted' : 'denied',
+					]
+				);
+
+				return self::normalize_state( is_array( $consent_defaults ) ? $consent_defaults : [] );
+			},
+		];
+
+		return $sources;
+	}
+
+	/**
+	 * Resolve the currently-active signal source.
+	 *
+	 * Iterates registered sources, filters by `is_active() === true`,
+	 * sorts by `priority` descending, returns the first descriptor.
+	 * Returns null if no source claims active.
+	 *
+	 * @return array<string, mixed>|null Active source descriptor or null.
+	 */
+	public function resolve(): ?array {
+		/**
+		 * Registry of consent signal sources. Highest-priority active source wins.
+		 *
+		 * @param array<string, array<string, mixed>> $sources Map keyed by source id.
+		 */
+		$sources = apply_filters( 'gtmkit_consent_signal_sources', [] );
+		if ( ! is_array( $sources ) ) {
+			return null;
+		}
+
+		$active = [];
+		foreach ( $sources as $descriptor ) {
+			if ( ! self::is_valid_descriptor( $descriptor ) ) {
+				continue;
+			}
+			if ( true === (bool) call_user_func( $descriptor['is_active'] ) ) {
+				$active[] = $descriptor;
+			}
+		}
+
+		if ( empty( $active ) ) {
+			return null;
+		}
+
+		usort(
+			$active,
+			static fn( array $a, array $b ): int => (int) $b['priority'] <=> (int) $a['priority']
+		);
+
+		return $active[0];
+	}
+
+	/**
+	 * Read consent state from the active source.
+	 *
+	 * @return array<string, string>|null
+	 *     Current state, or null if no source is active.
+	 */
+	public function read_state(): ?array {
+		$source = $this->resolve();
+		if ( null === $source ) {
+			return null;
+		}
+
+		$state = call_user_func( $source['read'] );
+
+		return self::normalize_state( is_array( $state ) ? $state : [] );
+	}
+
+	/**
+	 * Validate that an entry returned through the filter is shaped like a
+	 * source descriptor. Silently drops malformed entries instead of fataling.
+	 *
+	 * @param mixed $descriptor The candidate descriptor.
+	 */
+	private static function is_valid_descriptor( $descriptor ): bool {
+		if ( ! is_array( $descriptor ) ) {
+			return false;
+		}
+		if ( ! isset( $descriptor['id'], $descriptor['priority'], $descriptor['is_active'], $descriptor['read'] ) ) {
+			return false;
+		}
+		if ( ! is_string( $descriptor['id'] ) ) {
+			return false;
+		}
+		if ( ! is_callable( $descriptor['is_active'] ) || ! is_callable( $descriptor['read'] ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Coerce a state array to the canonical seven-category shape with
+	 * `granted`/`denied` values. Missing keys default to `denied`,
+	 * unknown values fall back to `denied`. Keeps the consent emission
+	 * resilient when a misbehaving source returns a partial array.
+	 *
+	 * @param array<string, mixed> $state Raw state from a source.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function normalize_state( array $state ): array {
+		$normalized = [];
+		foreach ( self::CATEGORIES as $category ) {
+			$value                   = $state[ $category ] ?? 'denied';
+			$normalized[ $category ] = ( $value === 'granted' ) ? 'granted' : 'denied';
+		}
+		return $normalized;
+	}
+}

--- a/src/Frontend/EventDeferralGate.php
+++ b/src/Frontend/EventDeferralGate.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * GTM Kit plugin file.
+ *
+ * @package GTM Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Frontend;
+
+/**
+ * Event deferral gate.
+ *
+ * Wraps the `gtmkit_event_should_defer` filter so the dataLayer push
+ * helpers in {@see Frontend} have a single, testable seam through which
+ * to ask "should I defer this event?". The default decision is false
+ * (events fire); a Premium-only event deferral queue can register on
+ * the filter and return true when consent is missing.
+ */
+final class EventDeferralGate {
+
+	/**
+	 * The signal source registry used to read the active consent state.
+	 *
+	 * @var ConsentSignalSourceRegistry
+	 */
+	private ConsentSignalSourceRegistry $registry;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ConsentSignalSourceRegistry $registry The signal source registry.
+	 */
+	public function __construct( ConsentSignalSourceRegistry $registry ) {
+		$this->registry = $registry;
+	}
+
+	/**
+	 * Decide whether to defer an event.
+	 *
+	 * Reads the current consent state from the active signal source
+	 * (or an empty array when no source is active) and runs the
+	 * `gtmkit_event_should_defer` filter. Returning true skips the
+	 * push at the call site.
+	 *
+	 * @param string               $event_name    e.g. 'view_item', 'add_to_cart', 'purchase'.
+	 * @param array<string, mixed> $event_payload Event data.
+	 */
+	public function should_defer( string $event_name, array $event_payload ): bool {
+		$consent_state = $this->registry->read_state() ?? [];
+
+		/**
+		 * Per-event deferral decision. Default: do not defer.
+		 *
+		 * @param bool                              $should_defer  Default false.
+		 * @param string                            $event_name    e.g. 'view_item', 'add_to_cart', 'purchase'.
+		 * @param array<string, mixed>              $event_payload Event data.
+		 * @param array<string, 'granted'|'denied'> $consent_state Current state from the active signal source.
+		 */
+		return (bool) apply_filters(
+			'gtmkit_event_should_defer',
+			false,
+			$event_name,
+			$event_payload,
+			$consent_state
+		);
+	}
+}

--- a/src/Frontend/Frontend.php
+++ b/src/Frontend/Frontend.php
@@ -29,13 +29,40 @@ final class Frontend {
 	protected string $datalayer_name;
 
 	/**
+	 * Consent signal source registry.
+	 *
+	 * @var ConsentSignalSourceRegistry
+	 */
+	protected ConsentSignalSourceRegistry $signal_source_registry;
+
+	/**
+	 * Event deferral gate.
+	 *
+	 * @var EventDeferralGate
+	 */
+	protected EventDeferralGate $event_deferral_gate;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param Options $options An instance of Options.
+	 * The registry and deferral gate default to fresh instances when
+	 * not supplied so existing call sites (`new Frontend( $options )`)
+	 * keep working; the bootstrap in `inc/main.php` wires explicit
+	 * services for the production request lifecycle.
+	 *
+	 * @param Options                          $options An instance of Options.
+	 * @param ConsentSignalSourceRegistry|null $signal_source_registry Optional pre-built registry.
+	 * @param EventDeferralGate|null           $event_deferral_gate    Optional pre-built deferral gate.
 	 */
-	public function __construct( Options $options ) {
-		$this->options        = $options;
-		$this->datalayer_name = ( $this->options->get( 'general', 'datalayer_name' ) ) ? $this->options->get( 'general', 'datalayer_name' ) : 'dataLayer';
+	public function __construct(
+		Options $options,
+		?ConsentSignalSourceRegistry $signal_source_registry = null,
+		?EventDeferralGate $event_deferral_gate = null
+	) {
+		$this->options                = $options;
+		$this->datalayer_name         = ( $this->options->get( 'general', 'datalayer_name' ) ) ? $this->options->get( 'general', 'datalayer_name' ) : 'dataLayer';
+		$this->signal_source_registry = $signal_source_registry ?? new ConsentSignalSourceRegistry( $options );
+		$this->event_deferral_gate    = $event_deferral_gate ?? new EventDeferralGate( $this->signal_source_registry );
 	}
 
 	/**
@@ -94,28 +121,6 @@ final class Frontend {
 		}
 
 		/**
-		 * Per-category Consent Mode v2 default state.
-		 *
-		 * Filters are applied even when the master toggle is off, so an
-		 * integrator can force-enable via {@see 'gtmkit_consent_default_settings_enabled'}
-		 * without editing the admin UI.
-		 *
-		 * @param array<string, 'granted'|'denied'> $consent_defaults The seven-category state.
-		 */
-		$consent_defaults = apply_filters(
-			'gtmkit_consent_default_state',
-			[
-				'ad_personalization'      => $this->options->get( 'general', 'gcm_ad_personalization' ) ? 'granted' : 'denied',
-				'ad_storage'              => $this->options->get( 'general', 'gcm_ad_storage' ) ? 'granted' : 'denied',
-				'ad_user_data'            => $this->options->get( 'general', 'gcm_ad_user_data' ) ? 'granted' : 'denied',
-				'analytics_storage'       => $this->options->get( 'general', 'gcm_analytics_storage' ) ? 'granted' : 'denied',
-				'personalization_storage' => $this->options->get( 'general', 'gcm_personalization_storage' ) ? 'granted' : 'denied',
-				'functionality_storage'   => $this->options->get( 'general', 'gcm_functionality_storage' ) ? 'granted' : 'denied',
-				'security_storage'        => $this->options->get( 'general', 'gcm_security_storage' ) ? 'granted' : 'denied',
-			]
-		);
-
-		/**
 		 * Region codes the consent defaults apply to.
 		 *
 		 * @param array<int, string> $consent_region Zero or more ISO region codes (e.g. `DK`, `DE-BY`, `US-CA`).
@@ -140,6 +145,40 @@ final class Frontend {
 			'gtmkit_consent_default_settings_enabled',
 			(bool) $this->options->get( 'general', 'gcm_default_settings' )
 		);
+
+		/**
+		 * Per-category Consent Mode v2 default state.
+		 *
+		 * Resolved through the signal source registry so Premium add-ons
+		 * (WP Consent API integration, named CMP integrations) can plug
+		 * in alternative state providers via the
+		 * {@see 'gtmkit_consent_signal_sources'} filter. The default
+		 * `gtmkit_default` source delegates to the legacy
+		 * {@see 'gtmkit_consent_default_state'} filter, so existing
+		 * integrations keep working unchanged.
+		 *
+		 * The registry is only consulted when the master toggle is on.
+		 * When off, the consent block is suppressed entirely so a CMP
+		 * or GTM-based consent solution can own the flow without
+		 * double-firing.
+		 *
+		 * @var array<string, string> $consent_defaults
+		 */
+		$consent_defaults = [
+			'ad_personalization'      => 'denied',
+			'ad_storage'              => 'denied',
+			'ad_user_data'            => 'denied',
+			'analytics_storage'       => 'denied',
+			'personalization_storage' => 'denied',
+			'functionality_storage'   => 'denied',
+			'security_storage'        => 'denied',
+		];
+		if ( $consent_enabled ) {
+			$resolved_state = $this->signal_source_registry->read_state();
+			if ( null !== $resolved_state ) {
+				$consent_defaults = $resolved_state;
+			}
+		}
 
 		$wait_for_update    = (int) $this->options->get( 'general', 'gcm_wait_for_update' );
 		$ads_data_redaction = (bool) $this->options->get( 'general', 'gcm_ads_data_redaction' );
@@ -218,6 +257,16 @@ final class Frontend {
 	public function enqueue_datalayer_content(): void {
 
 		$datalayer_data = apply_filters( 'gtmkit_datalayer_content', [] );
+		if ( ! is_array( $datalayer_data ) ) {
+			$datalayer_data = [];
+		}
+
+		// Ask the deferral gate before pushing. A Premium-only event deferral queue can return true here
+		// when consent is missing for the categories this event requires; default returns false.
+		$event_name = isset( $datalayer_data['event'] ) && is_string( $datalayer_data['event'] ) ? $datalayer_data['event'] : '';
+		if ( $this->event_deferral_gate->should_defer( $event_name, $datalayer_data ) ) {
+			return;
+		}
 
 		$script  = 'const gtmkit_dataLayer_content = ' . wp_json_encode( $datalayer_data ) . ";\n";
 		$script .= esc_attr( $this->datalayer_name ) . '.push( gtmkit_dataLayer_content );' . "\n";
@@ -278,6 +327,11 @@ final class Frontend {
 	 * This script fires the 'delay_js' event in Google Tag Manager
 	 */
 	public function enqueue_delay_js_script(): void {
+
+		$payload = [ 'event' => 'load_delayed_js' ];
+		if ( $this->event_deferral_gate->should_defer( 'load_delayed_js', $payload ) ) {
+			return;
+		}
 
 		$script = esc_attr( $this->datalayer_name ) . '.push({"event" : "load_delayed_js"});' . "\n";
 

--- a/tests/phpunit/Integration/Consent/BackwardCompatTest.php
+++ b/tests/phpunit/Integration/Consent/BackwardCompatTest.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Backward-compatibility integration tests for the Consent Mode v2 default
+ * emission after the signal source registry was introduced.
+ *
+ * The signal source registry replaces the direct call to
+ * `apply_filters('gtmkit_consent_default_state', ...)` in
+ * {@see Frontend::enqueue_settings_and_data_script()}. The default
+ * `gtmkit_default` source delegates to that filter, so for the
+ * no-extra-sources case the rendered output must remain
+ * **byte-identical** to the previous baseline.
+ *
+ * Approach: pin the rendered inline script to a snapshot for two
+ * canonical configurations (master toggle off; master toggle on with all
+ * categories denied), and pin the structural shape with literal substring
+ * assertions. The snapshot is the strict regression net; the structural
+ * checks make the failure mode actionable when the snapshot drifts.
+ *
+ * Snapshot files live in `tests/phpunit/Integration/Consent/fixtures/`.
+ * To regenerate after an intentional change, delete the relevant fixture
+ * and re-run the test — it will write the new fixture and pass.
+ *
+ * @package TLA_Media\GTM_Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Tests\Integration\Consent;
+
+use TLA_Media\GTM_Kit\Frontend\Frontend;
+use TLA_Media\GTM_Kit\Options\OptionsFactory;
+use WP_UnitTestCase;
+
+/**
+ * Pins the legacy emission contract so the registry refactor cannot
+ * silently shift any byte in the default rendered script.
+ */
+final class BackwardCompatTest extends WP_UnitTestCase {
+
+	/**
+	 * The seven Consent Mode v2 categories, in canonical order.
+	 *
+	 * @var array<int, string>
+	 */
+	private const CONSENT_OPTION_KEYS = [
+		'gcm_ad_personalization',
+		'gcm_ad_storage',
+		'gcm_ad_user_data',
+		'gcm_analytics_storage',
+		'gcm_personalization_storage',
+		'gcm_functionality_storage',
+		'gcm_security_storage',
+	];
+
+	/**
+	 * Reset state so every assertion observes a clean WP scripts registry
+	 * and clean filter chains.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		wp_cache_delete( 'gtmkit_script_settings', 'gtmkit' );
+		wp_scripts()->remove( 'gtmkit' );
+		remove_all_filters( 'gtmkit_consent_signal_sources' );
+		remove_all_filters( 'gtmkit_consent_default_state' );
+		remove_all_filters( 'gtmkit_consent_default_settings_enabled' );
+		remove_all_filters( 'gtmkit_consent_region' );
+		remove_all_filters( 'gtmkit_header_script_settings' );
+		remove_all_filters( 'gtmkit_header_script_data' );
+	}
+
+	/**
+	 * With master toggle on and all seven categories denied, the rendered
+	 * inline script preserves the canonical pre-registry byte sequence.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_settings_and_data_script
+	 */
+	public function test_default_emission_byte_identical_when_no_extras_registered(): void {
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gcm_default_settings', 1 );
+		foreach ( self::CONSENT_OPTION_KEYS as $key ) {
+			$options->set_option( 'general', $key, 0 );
+		}
+		$options->set_option( 'general', 'gcm_region', [] );
+		$options->set_option( 'general', 'gcm_wait_for_update', 0 );
+		$options->set_option( 'general', 'gcm_ads_data_redaction', 0 );
+		$options->set_option( 'general', 'gcm_url_passthrough', 0 );
+		$options->set_option( 'general', 'console_log', '' );
+		$options->set_option( 'general', 'datalayer_name', '' );
+
+		( new Frontend( $options ) )->enqueue_settings_and_data_script();
+		$inline = $this->extract_inline_script();
+
+		$this->assertSnapshot( 'default-emission-all-denied.snapshot.js', $inline );
+
+		// Structural asserts that make a hash mismatch readable.
+		$this->assertStringContainsString( "gtag('consent', 'default'", $inline );
+		$this->assertStringContainsString( "'ad_personalization': 'denied'", $inline );
+		$this->assertStringContainsString( "'security_storage': 'denied'", $inline );
+		$this->assertSame( 7, substr_count( $inline, "'denied'" ) );
+		$this->assertSame( 0, substr_count( $inline, "'granted'" ) );
+
+		// Negative regression: no leakage of registry/gate internals into the rendered output.
+		$this->assertStringNotContainsString( 'signal_source', $inline );
+		$this->assertStringNotContainsString( 'deferral_gate', $inline );
+		$this->assertStringNotContainsString( 'gtmkit_consent_signal_sources', $inline );
+	}
+
+	/**
+	 * With the master toggle off, the inline script emits no consent
+	 * surface area — same as the pre-registry baseline.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_settings_and_data_script
+	 */
+	public function test_master_toggle_off_emits_no_consent_block(): void {
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gcm_default_settings', 0 );
+		$options->set_option( 'general', 'datalayer_name', '' );
+		$options->set_option( 'general', 'console_log', '' );
+
+		( new Frontend( $options ) )->enqueue_settings_and_data_script();
+		$inline = $this->extract_inline_script();
+
+		$this->assertSnapshot( 'master-toggle-off.snapshot.js', $inline );
+
+		$this->assertStringNotContainsString( "gtag('consent', 'default'", $inline );
+		$this->assertStringNotContainsString( 'window.gtmkit.consent', $inline );
+		$this->assertStringNotContainsString( 'gtmkit:consent:updated', $inline );
+	}
+
+	/**
+	 * The category emission order matches the canonical pre-registry order.
+	 * Captured separately so an order regression is named in the failure.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_settings_and_data_script
+	 */
+	public function test_category_emission_order_is_canonical(): void {
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gcm_default_settings', 1 );
+		foreach ( self::CONSENT_OPTION_KEYS as $key ) {
+			$options->set_option( 'general', $key, 0 );
+		}
+
+		( new Frontend( $options ) )->enqueue_settings_and_data_script();
+		$inline = $this->extract_inline_script();
+
+		$expected_order = [
+			'ad_personalization',
+			'ad_storage',
+			'ad_user_data',
+			'analytics_storage',
+			'personalization_storage',
+			'functionality_storage',
+			'security_storage',
+		];
+		$last_position  = -1;
+		foreach ( $expected_order as $category ) {
+			$needle   = "'" . $category . "':";
+			$position = strpos( $inline, $needle );
+			$this->assertNotFalse( $position, "Category '{$category}' missing from emission." );
+			$this->assertGreaterThan( $last_position, $position, "Category '{$category}' is out of canonical order." );
+			$last_position = $position;
+		}
+	}
+
+	/**
+	 * Compare actual script output to a fixture file. If the fixture does
+	 * not exist, write it and skip the test — so the next run pins it.
+	 *
+	 * @param string $fixture_filename Filename under fixtures/.
+	 * @param string $actual           The rendered inline script.
+	 *
+	 * @return void
+	 */
+	private function assertSnapshot( string $fixture_filename, string $actual ): void {
+		$fixture_dir = __DIR__ . '/fixtures';
+		if ( ! is_dir( $fixture_dir ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- WP_Filesystem is not initialized in the test bootstrap; tests run outside the request lifecycle that wires it up.
+			mkdir( $fixture_dir, 0755, true );
+		}
+		$fixture_path = $fixture_dir . '/' . $fixture_filename;
+
+		if ( ! file_exists( $fixture_path ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- WP_Filesystem is not initialized in the test bootstrap; tests run outside the request lifecycle that wires it up.
+			file_put_contents( $fixture_path, $actual );
+			$this->markTestSkipped(
+				sprintf(
+					'Snapshot fixture %s did not exist and was just written. Re-run to verify.',
+					$fixture_filename
+				)
+			);
+		}
+
+		$this->assertStringEqualsFile(
+			$fixture_path,
+			$actual,
+			sprintf(
+				'Rendered emission diverged from snapshot %s. If this drift is intentional, delete the fixture and re-run.',
+				$fixture_filename
+			)
+		);
+	}
+
+	/**
+	 * Pull the `before`-position inline script for the `gtmkit` handle.
+	 *
+	 * @return string
+	 */
+	private function extract_inline_script(): string {
+		$data = wp_scripts()->get_data( 'gtmkit', 'before' );
+		if ( is_array( $data ) ) {
+			return implode( '', $data );
+		}
+		return (string) $data;
+	}
+}

--- a/tests/phpunit/Integration/Consent/FilterHooksTest.php
+++ b/tests/phpunit/Integration/Consent/FilterHooksTest.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Integration tests for the consent developer filter and action hooks.
+ *
+ * Covers:
+ *
+ *  - The `gtmkit_consent_updated` action fires with the documented
+ *    signature when a registered listener calls it.
+ *  - The `gtmkit_event_should_defer` filter is invoked by the deferral
+ *    gate at the dataLayer push helper, defaults to false (events push),
+ *    and skips the push when a listener returns true.
+ *
+ * Targets:
+ *
+ *  - {@see \TLA_Media\GTM_Kit\Frontend\EventDeferralGate}
+ *  - {@see \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_datalayer_content}
+ *  - {@see \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_delay_js_script}
+ *
+ * @package TLA_Media\GTM_Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Tests\Integration\Consent;
+
+use TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry;
+use TLA_Media\GTM_Kit\Frontend\EventDeferralGate;
+use TLA_Media\GTM_Kit\Frontend\Frontend;
+use TLA_Media\GTM_Kit\Options\OptionsFactory;
+use WP_UnitTestCase;
+
+/**
+ * Covers the new action `gtmkit_consent_updated` and the new filter
+ * `gtmkit_event_should_defer`.
+ */
+final class FilterHooksTest extends WP_UnitTestCase {
+
+	/**
+	 * Reset the WP scripts registry, the cached gtmkit settings, and the
+	 * consent-related filters so each test sees a clean slate.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		wp_cache_delete( 'gtmkit_script_settings', 'gtmkit' );
+		wp_scripts()->remove( 'gtmkit' );
+		wp_scripts()->remove( 'gtmkit-datalayer' );
+		wp_scripts()->remove( 'gtmkit-delay' );
+		remove_all_filters( 'gtmkit_consent_signal_sources' );
+		remove_all_filters( 'gtmkit_event_should_defer' );
+		remove_all_filters( 'gtmkit_datalayer_content' );
+		remove_all_actions( 'gtmkit_consent_updated' );
+	}
+
+	/**
+	 * The `gtmkit_consent_updated` action fires with the documented
+	 * `($new_state, $source_id)` signature.
+	 *
+	 * @covers ::do_action
+	 */
+	public function test_consent_updated_action_fires_with_expected_signature(): void {
+		$captured = [];
+		add_action(
+			'gtmkit_consent_updated',
+			static function ( $new_state, $source_id ) use ( &$captured ): void {
+				$captured = [ $new_state, $source_id ];
+			},
+			10,
+			2
+		);
+
+		do_action(
+			'gtmkit_consent_updated',
+			[
+				'analytics_storage' => 'granted',
+				'ad_storage'        => 'denied',
+			],
+			'wp_consent_api'
+		);
+
+		$this->assertCount( 2, $captured, 'Action listener must receive both arguments.' );
+		$this->assertSame( 'granted', $captured[0]['analytics_storage'] );
+		$this->assertSame( 'denied', $captured[0]['ad_storage'] );
+		$this->assertSame( 'wp_consent_api', $captured[1] );
+	}
+
+	/**
+	 * The `gtmkit_event_should_defer` filter defaults to false — events
+	 * push as normal.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\EventDeferralGate::should_defer
+	 */
+	public function test_event_should_defer_defaults_to_false(): void {
+		$options  = OptionsFactory::get_instance();
+		$registry = new ConsentSignalSourceRegistry( $options );
+		$gate     = new EventDeferralGate( $registry );
+
+		$this->assertFalse( $gate->should_defer( 'view_item', [ 'event' => 'view_item' ] ) );
+	}
+
+	/**
+	 * The deferral gate calls the filter with all four documented
+	 * arguments: ($should_defer, $event_name, $event_payload, $consent_state).
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\EventDeferralGate::should_defer
+	 */
+	public function test_deferral_filter_receives_documented_signature(): void {
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gcm_default_settings', 1 );
+		$options->set_option( 'general', 'gcm_analytics_storage', 1 );
+		$registry = new ConsentSignalSourceRegistry( $options );
+		$gate     = new EventDeferralGate( $registry );
+
+		$captured = [];
+		add_filter(
+			'gtmkit_event_should_defer',
+			static function ( $should_defer, $event_name, $event_payload, $consent_state ) use ( &$captured ) {
+				$captured = [ $should_defer, $event_name, $event_payload, $consent_state ];
+				return $should_defer;
+			},
+			10,
+			4
+		);
+
+		$gate->should_defer(
+			'add_to_cart',
+			[
+				'event' => 'add_to_cart',
+				'value' => 42,
+			]
+		);
+
+		$this->assertSame( false, $captured[0], 'Default $should_defer must be false.' );
+		$this->assertSame( 'add_to_cart', $captured[1] );
+		$this->assertSame(
+			[
+				'event' => 'add_to_cart',
+				'value' => 42,
+			],
+			$captured[2]
+		);
+		$this->assertSame( 'granted', $captured[3]['analytics_storage'], 'Consent state passed to filter must reflect active source.' );
+	}
+
+	/**
+	 * When the filter returns true, the dataLayer push helper skips the
+	 * push entirely — no inline script is registered.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_datalayer_content
+	 */
+	public function test_returning_true_from_filter_skips_datalayer_push(): void {
+		$options = OptionsFactory::get_instance();
+
+		add_filter(
+			'gtmkit_datalayer_content',
+			static fn() => [
+				'event' => 'purchase',
+				'value' => 99,
+			]
+		);
+		add_filter( 'gtmkit_event_should_defer', '__return_true' );
+
+		( new Frontend( $options ) )->enqueue_datalayer_content();
+
+		$this->assertFalse(
+			wp_scripts()->query( 'gtmkit-datalayer' ),
+			'Deferred event must not register the gtmkit-datalayer inline script.'
+		);
+	}
+
+	/**
+	 * Default behavior (filter returns false): the dataLayer push helper
+	 * registers the inline script and the payload appears in it.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_datalayer_content
+	 */
+	public function test_default_path_pushes_datalayer_content(): void {
+		$options = OptionsFactory::get_instance();
+
+		add_filter(
+			'gtmkit_datalayer_content',
+			static fn() => [
+				'event' => 'view_item',
+				'value' => 7,
+			]
+		);
+
+		( new Frontend( $options ) )->enqueue_datalayer_content();
+
+		$inline = $this->extract_inline_script( 'gtmkit-datalayer' );
+		$this->assertStringContainsString( '"event":"view_item"', $inline, 'Default path must emit the event payload.' );
+	}
+
+	/**
+	 * The delay-js push site also honors the deferral gate.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_delay_js_script
+	 */
+	public function test_returning_true_from_filter_skips_delay_js_push(): void {
+		$options = OptionsFactory::get_instance();
+
+		add_filter(
+			'gtmkit_event_should_defer',
+			static function ( $should_defer, $event_name ) {
+				return $event_name === 'load_delayed_js' ? true : $should_defer;
+			},
+			10,
+			2
+		);
+
+		( new Frontend( $options ) )->enqueue_delay_js_script();
+
+		$this->assertFalse(
+			wp_scripts()->query( 'gtmkit-delay' ),
+			'Deferred load_delayed_js must not register the gtmkit-delay inline script.'
+		);
+	}
+
+	/**
+	 * Pull the `before`-position inline script for a given handle.
+	 *
+	 * @param string $handle The script handle.
+	 *
+	 * @return string
+	 */
+	private function extract_inline_script( string $handle ): string {
+		$data = wp_scripts()->get_data( $handle, 'before' );
+		if ( is_array( $data ) ) {
+			return implode( '', $data );
+		}
+		return (string) $data;
+	}
+}

--- a/tests/phpunit/Integration/Consent/SignalSourceRegistryTest.php
+++ b/tests/phpunit/Integration/Consent/SignalSourceRegistryTest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Integration tests for the consent signal source registry.
+ *
+ * Covers the three resolution behaviors third-party code relies on:
+ *
+ *  1. With no extra registrations, the registry resolves to the
+ *     `gtmkit_default` source (the legacy fallback for backward
+ *     compatibility with the original Consent Mode v2 emission).
+ *  2. A higher-priority active source replaces the default.
+ *  3. Inactive sources are skipped even at high priority, and removing
+ *     the default falls through to the next-highest active source —
+ *     or returns null when no source claims active.
+ *
+ * Target: {@see \TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry}.
+ *
+ * @package TLA_Media\GTM_Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Tests\Integration\Consent;
+
+use TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry;
+use TLA_Media\GTM_Kit\Options\OptionsFactory;
+use WP_UnitTestCase;
+
+/**
+ * Covers source registration, prioritization, and resolution.
+ */
+final class SignalSourceRegistryTest extends WP_UnitTestCase {
+
+	/**
+	 * Reset the signal source filter so each test sees a clean registry.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		remove_all_filters( 'gtmkit_consent_signal_sources' );
+		remove_all_filters( 'gtmkit_consent_default_state' );
+		remove_all_filters( 'gtmkit_consent_default_settings_enabled' );
+	}
+
+	/**
+	 * With no extra sources registered, the registry resolves to
+	 * `gtmkit_default` and reads through the legacy
+	 * `gtmkit_consent_default_state` filter.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry::resolve
+	 * @covers \TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry::read_state
+	 */
+	public function test_resolves_to_default_source_when_no_extras_registered(): void {
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gcm_default_settings', 1 );
+		$options->set_option( 'general', 'gcm_analytics_storage', 1 );
+
+		$registry = new ConsentSignalSourceRegistry( $options );
+
+		$resolved = $registry->resolve();
+		$this->assertIsArray( $resolved, 'Registry must resolve to a source when the master toggle is on.' );
+		$this->assertSame( ConsentSignalSourceRegistry::DEFAULT_SOURCE_ID, $resolved['id'] );
+
+		$state = $registry->read_state();
+		$this->assertSame( 'granted', $state['analytics_storage'], 'Default source reads through to the option-backed state.' );
+		$this->assertSame( 'denied', $state['ad_storage'], 'Categories without a flag default to denied.' );
+	}
+
+	/**
+	 * Registering a higher-priority active source replaces the default
+	 * in `read_state()`.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry::resolve
+	 * @covers \TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry::read_state
+	 */
+	public function test_higher_priority_source_wins(): void {
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gcm_default_settings', 1 );
+
+		$registry = new ConsentSignalSourceRegistry( $options );
+
+		add_filter(
+			'gtmkit_consent_signal_sources',
+			static function ( $sources ) {
+				$sources['custom_cmp'] = [
+					'id'        => 'custom_cmp',
+					'priority'  => 100,
+					'is_active' => '__return_true',
+					'read'      => static function (): array {
+						return [
+							'ad_personalization'      => 'granted',
+							'ad_storage'              => 'granted',
+							'ad_user_data'            => 'granted',
+							'analytics_storage'       => 'granted',
+							'personalization_storage' => 'granted',
+							'functionality_storage'   => 'granted',
+							'security_storage'        => 'granted',
+						];
+					},
+				];
+				return $sources;
+			}
+		);
+
+		$resolved = $registry->resolve();
+		$this->assertSame( 'custom_cmp', $resolved['id'] );
+
+		$state = $registry->read_state();
+		$this->assertSame( 'granted', $state['analytics_storage'] );
+		$this->assertSame( 'granted', $state['ad_storage'] );
+	}
+
+	/**
+	 * An inactive source is skipped even at high priority; the default
+	 * source still wins.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry::resolve
+	 */
+	public function test_inactive_source_is_skipped_even_at_high_priority(): void {
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gcm_default_settings', 1 );
+
+		$registry = new ConsentSignalSourceRegistry( $options );
+
+		add_filter(
+			'gtmkit_consent_signal_sources',
+			static function ( $sources ) {
+				$sources['standby_cmp'] = [
+					'id'        => 'standby_cmp',
+					'priority'  => 100,
+					'is_active' => '__return_false',
+					'read'      => static fn(): array => [],
+				];
+				return $sources;
+			}
+		);
+
+		$resolved = $registry->resolve();
+		$this->assertSame( ConsentSignalSourceRegistry::DEFAULT_SOURCE_ID, $resolved['id'] );
+	}
+
+	/**
+	 * Unsetting the default source via the filter falls through to the
+	 * next-highest active source.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry::resolve
+	 */
+	public function test_unsetting_default_falls_through_to_next_active(): void {
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gcm_default_settings', 1 );
+
+		$registry = new ConsentSignalSourceRegistry( $options );
+
+		// Register a low-priority alternative.
+		add_filter(
+			'gtmkit_consent_signal_sources',
+			static function ( $sources ) {
+				$sources['fallback_source'] = [
+					'id'        => 'fallback_source',
+					'priority'  => 5,
+					'is_active' => '__return_true',
+					'read'      => static fn(): array => [ 'analytics_storage' => 'granted' ],
+				];
+				return $sources;
+			}
+		);
+
+		// Remove the default source after the registry's bootstrap callback runs.
+		add_filter(
+			'gtmkit_consent_signal_sources',
+			static function ( $sources ) {
+				unset( $sources[ ConsentSignalSourceRegistry::DEFAULT_SOURCE_ID ] );
+				return $sources;
+			},
+			20
+		);
+
+		$resolved = $registry->resolve();
+		$this->assertSame( 'fallback_source', $resolved['id'] );
+	}
+
+	/**
+	 * When no source claims active, `read_state()` returns null and
+	 * Frontend can decide to suppress the consent block.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry::read_state
+	 */
+	public function test_returns_null_when_no_active_sources(): void {
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gcm_default_settings', 0 );
+
+		$registry = new ConsentSignalSourceRegistry( $options );
+
+		// Force the master toggle filter false so even the default is inactive.
+		add_filter( 'gtmkit_consent_default_settings_enabled', '__return_false' );
+
+		$this->assertNull( $registry->resolve() );
+		$this->assertNull( $registry->read_state() );
+	}
+
+	/**
+	 * Malformed descriptors returned through the filter are silently
+	 * dropped instead of fataling.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\ConsentSignalSourceRegistry::resolve
+	 */
+	public function test_malformed_descriptor_is_ignored(): void {
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gcm_default_settings', 1 );
+
+		$registry = new ConsentSignalSourceRegistry( $options );
+
+		add_filter(
+			'gtmkit_consent_signal_sources',
+			static function ( $sources ) {
+				$sources['broken']      = [ 'this' => 'is not a descriptor' ];
+				$sources['also_broken'] = 'not even an array';
+				return $sources;
+			}
+		);
+
+		$resolved = $registry->resolve();
+		$this->assertSame( ConsentSignalSourceRegistry::DEFAULT_SOURCE_ID, $resolved['id'] );
+	}
+}

--- a/tests/phpunit/Integration/Consent/fixtures/default-emission-all-denied.snapshot.js
+++ b/tests/phpunit/Integration/Consent/fixtures/default-emission-all-denied.snapshot.js
@@ -1,0 +1,27 @@
+		window.gtmkit_settings = {"datalayer_name":"dataLayer","console_log":""};
+		window.gtmkit_data = {};
+		window.dataLayer = window.dataLayer || [];
+				if (typeof gtag === "undefined") {
+			function gtag(){dataLayer.push(arguments);}
+			gtag('consent', 'default', {
+				'ad_personalization': 'denied',
+				'ad_storage': 'denied',
+				'ad_user_data': 'denied',
+				'analytics_storage': 'denied',
+				'personalization_storage': 'denied',
+				'functionality_storage': 'denied',
+				'security_storage': 'denied'
+			});
+								} else if ( window.gtmkit_settings.console_log === 'on' ) {
+			console.warn('GTM Kit: gtag is already defined')
+		}
+		window.gtmkit = window.gtmkit || {};
+		window.gtmkit.consent = {
+			update: function (state) {
+				if (typeof gtag !== 'undefined') {
+					gtag('consent', 'update', state);
+				}
+				window.dispatchEvent(new CustomEvent('gtmkit:consent:updated', { detail: state }));
+			}
+		};
+				

--- a/tests/phpunit/Integration/Consent/fixtures/master-toggle-off.snapshot.js
+++ b/tests/phpunit/Integration/Consent/fixtures/master-toggle-off.snapshot.js
@@ -1,0 +1,4 @@
+		window.gtmkit_settings = {"datalayer_name":"dataLayer","console_log":""};
+		window.gtmkit_data = {};
+		window.dataLayer = window.dataLayer || [];
+				


### PR DESCRIPTION
Introduce three new developer hooks so CMP integrations and consent add-ons can plug into GTM Kit's consent flow without forking core:

- gtmkit_consent_signal_sources (filter, registry of state providers)
- gtmkit_consent_updated (action, server-side state-change broadcast)
- gtmkit_event_should_defer (filter, per-event push gate)

ConsentSignalSourceRegistry resolves the highest-priority active source. The default gtmkit_default source registers itself at filter priority 1 and delegates to the existing gtmkit_consent_default_state filter, so output stays byte-identical when no extra sources are registered. The registry is consulted only when the master toggle is on, preserving CMP coexistence.

EventDeferralGate wraps the new filter and is consulted by the dataLayer and delay-js push helpers; default returns false so events push as before.