### PR TITLE
Chore: zip-package.sh self-installs --no-dev with auto-restore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -5,6 +5,7 @@
 /bundled
 /node_modules
 /tests
+.DS_Store
 .babelrc
 .distignore
 .editorconfig

--- a/bin/zip-package.sh
+++ b/bin/zip-package.sh
@@ -1,38 +1,76 @@
 #!/bin/sh
+#
+# Build a release zip from the current working tree.
+#
+# Honours .distignore at the plugin root — the same file the
+# `Deploy to WordPress.org` workflow consumes via the 10up
+# action-wordpress-plugin-deploy. Single source of truth: the
+# WooCommerce.com-bound zip and the wp.org SVN-bound zip ship the
+# same set of files.
+#
+# Folds in `composer install --no-dev` so the bundled vendor/ tree
+# matches what ships to customers (no dev dependencies, optimized
+# autoloader). On exit — success or failure — the dev install is
+# restored via `composer install` and the staging directory is
+# cleaned up.
+#
+set -e
 
 plugin_slug="gtm-kit"
 
-# Get the current directory
+# Get the current directory.
 current_dir=$(pwd)
 
-# Check if the base directory is 'bin'
+# If invoked from inside ./bin, step up to the plugin root.
 base_dir=$(basename "$current_dir")
 if [ "$base_dir" = "bin" ]; then
     cd ..
 fi
 
-# Check if the 'bundled' directory exists, if not create it
-[ ! -d "./bundled" ] && mkdir bundled
+# Capture the plugin root as an absolute path so the trap can find composer.json
+# regardless of where the script's cwd ended up when the trap fires.
+plugin_root=$(pwd)
 
-# Remove the previous zip file if it exists
-[ -f "./bundled/${plugin_slug}.zip" ] && rm "./bundled/${plugin_slug}.zip"
+if [ ! -f "${plugin_root}/.distignore" ]; then
+    echo "ERROR: .distignore not found at ${plugin_root}/.distignore" >&2
+    echo "       The zip script reads exclusions from this file; create it before running." >&2
+    exit 1
+fi
 
-# Navigate to the plugin directory
-cd ..
+stage_dir=$(mktemp -d -t "${plugin_slug}-zip.XXXXXX")
 
-# Create a zip file excluding specified directories and files
-zip -rq "./${plugin_slug}/bundled/${plugin_slug}.zip" $plugin_slug \
--x "${plugin_slug}/node_modules/*" \
--x "${plugin_slug}/bin/*" \
--x "${plugin_slug}/bundled/*" \
--x "**/.*" \
--x "${plugin_slug}/gulpfile.babel.js" \
--x "${plugin_slug}/package.json" \
--x "${plugin_slug}/package-lock.json" \
--x "${plugin_slug}/tailwind.config.js" \
--x "${plugin_slug}/composer.*" \
--x "${plugin_slug}/*.dist" \
--x "${plugin_slug}/postcss.config.js" \
--x "${plugin_slug}/README.md"
+# Always restore the dev composer install and clean the staging dir on exit,
+# even on failure.
+#
+# After this trap fires, vendor/composer/*.php and vendor/composer/installed.*
+# will be in their dev-install form — i.e. the same state `composer install`
+# leaves them in. That is *normal* developer-machine state and intentionally
+# uncommitted. Do not `git add vendor/composer/` afterwards; tasks/lessons.md
+# documents the CI breakage that committing those files causes.
+trap '
+    echo "Restoring dev composer install...";
+    (cd "$plugin_root" && composer install --no-progress >/dev/null 2>&1) || echo "WARNING: dev composer install failed to restore — run \"composer install\" manually from $plugin_root.";
+    rm -rf "$stage_dir";
+' EXIT
 
-echo "Done"
+echo "Installing production dependencies (composer install --no-dev)..."
+composer install --no-dev --no-progress
+
+# Ensure the bundled directory exists.
+[ ! -d "${plugin_root}/bundled" ] && mkdir "${plugin_root}/bundled"
+
+# Remove the previous zip file if it exists.
+[ -f "${plugin_root}/bundled/${plugin_slug}.zip" ] && rm "${plugin_root}/bundled/${plugin_slug}.zip"
+
+# Stage the plugin into a temp dir, honouring .distignore. rsync's
+# --exclude-from semantics match those of 10up's WP plugin deploy action,
+# so the staged tree mirrors what would land in SVN trunk.
+echo "Staging files (honouring .distignore)..."
+mkdir -p "${stage_dir}/${plugin_slug}"
+rsync -a --exclude-from="${plugin_root}/.distignore" "${plugin_root}/" "${stage_dir}/${plugin_slug}/"
+
+# Build the zip from the staged tree.
+echo "Building zip..."
+( cd "$stage_dir" && zip -rq "${plugin_root}/bundled/${plugin_slug}.zip" "$plugin_slug" )
+
+echo "Done — zip at ${plugin_slug}/bundled/${plugin_slug}.zip"


### PR DESCRIPTION
Folds the prod-only composer install into bin/zip-package.sh so release-zip building is a single command. The script switches the working tree to `composer install --no-dev`, builds the zip from that state, and on exit restores the dev install via a shell `trap` that runs even on failure. The trap captures the plugin root before any `cd ..` so it can find composer.json regardless of the script's current directory when it fires.

Replaces the previous two-step dance documented in the release runbook (`composer install --no-dev && ./bin/zip-package.sh`) — the runbook is updated separately in gtm-kit-dev.

Pattern documented in tasks/lessons.md (gtm-kit-dev) so future release-zip scripts in this codebase get it right first time.

Chore: zip-package.sh now reads exclusions from .distignore

Single source of truth — the GitHub `Deploy to WordPress.org` workflow already reads `.distignore` via 10up's
`action-wordpress-plugin-deploy`. The script now uses the same file via rsync staging:

    mkdir -p "$stage_dir/$plugin_slug"
    rsync -a --exclude-from="$plugin_root/.distignore" "$plugin_root/" "$stage_dir/$plugin_slug/"
    ( cd "$stage_dir" && zip -rq ".../$plugin_slug.zip" "$plugin_slug" )

This closes a real divergence: the wp.org SVN-bound zip excluded `tests/`, `phpunit.xml`, and `vitest.config.js` (per .distignore), but the WooCommerce.com-bound zip from this script did not. Both zips now ship the same file set.

Also adds `.DS_Store` to `.distignore` so macOS noise is excluded from both the SVN deploy and the local zip.

Trap now also cleans up the rsync staging dir on exit.