### PR TITLE
Add: gtmkit_consent_admin_badges filter surface for the Consent settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** GTM Kit ***
 
+Unreleased
+* Add: New `gtmkit_consent_admin_badges` filter lets add-ons (e.g. Premium's WP Consent API integration) push status banners onto the Consent settings page so users see immediately when a higher-priority consent source has taken over.
+
 2026-05-06 - version 2.10.0
 * Add: New "CMP script attributes" section on the Consent settings page lets you toggle Cookiebot, Iubenda, and CookieYes script-blocking attributes with one click and add a custom attribute for any other CMP — no PHP filters required.
 * Add: Fresh installs auto-detect a known CMP plugin (Cookiebot, Iubenda, CookieYes) and pre-select the matching toggle so the right attribute is on from day one.

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,11 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= Unreleased =
+
+#### New:
+* New `gtmkit_consent_admin_badges` filter lets add-ons (e.g. Premium's WP Consent API integration) push status banners onto the Consent settings page so users see immediately when a higher-priority consent source has taken over.
+
 = 2.10.0 =
 
 Release date: 2026-05-06

--- a/src/Admin/GeneralOptionsPage.php
+++ b/src/Admin/GeneralOptionsPage.php
@@ -139,21 +139,61 @@ final class GeneralOptionsPage extends AbstractOptionsPage {
 			'gtmkit-' . $script_handle . '-script',
 			'gtmkitSettings',
 			[
-				'rootId'        => 'gtmkit-settings',
-				'currentPage'   => $page_slug,
-				'root'          => \esc_url_raw( rest_url() ),
-				'nonce'         => \wp_create_nonce( 'wp_rest' ),
-				'pluginUrl'     => GTMKIT_URL,
-				'isPremium'     => ( new PremiumConditional() )->is_met(),
-				'tutorials'     => $this->get_tutorials(),
-				'integrations'  => Integrations::get_integrations(),
-				'adminPageUrl'  => $this->util->get_admin_page_url(),
-				'settings'      => $this->options->get_all_raw(),
-				'site_data'     => $this->util->get_site_data( $this->options->get_all_raw() ),
-				'user_roles'    => $this->get_user_roles(),
-				'notifications' => $this->get_notifications(),
+				'rootId'             => 'gtmkit-settings',
+				'currentPage'        => $page_slug,
+				'root'               => \esc_url_raw( rest_url() ),
+				'nonce'              => \wp_create_nonce( 'wp_rest' ),
+				'pluginUrl'          => GTMKIT_URL,
+				'isPremium'          => ( new PremiumConditional() )->is_met(),
+				'tutorials'          => $this->get_tutorials(),
+				'integrations'       => Integrations::get_integrations(),
+				'adminPageUrl'       => $this->util->get_admin_page_url(),
+				'settings'           => $this->options->get_all_raw(),
+				'site_data'          => $this->util->get_site_data( $this->options->get_all_raw() ),
+				'user_roles'         => $this->get_user_roles(),
+				'notifications'      => $this->get_notifications(),
+				'consentAdminBadges' => $this->get_consent_admin_badges(),
 			]
 		);
+	}
+
+	/**
+	 * Resolve the admin status badges rendered above the Consent settings
+	 * page sections.
+	 *
+	 * Add-ons (e.g. the Premium WP Consent API integration) hook
+	 * `gtmkit_consent_admin_badges` to push entries shaped as
+	 * `[ 'id' => string, 'message' => string, 'severity' => 'info'|'warning'|'success'|'error' ]`.
+	 * The React app renders each entry as a Notice at the top of the
+	 * Consent page, so users see immediately when a higher-priority
+	 * consent source has taken over from the standard admin defaults.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	private function get_consent_admin_badges(): array {
+		$badges = (array) apply_filters( 'gtmkit_consent_admin_badges', [] );
+
+		$normalised = [];
+		foreach ( $badges as $badge ) {
+			if ( ! is_array( $badge ) ) {
+				continue;
+			}
+			$id       = isset( $badge['id'] ) ? (string) $badge['id'] : '';
+			$message  = isset( $badge['message'] ) ? (string) $badge['message'] : '';
+			$severity = isset( $badge['severity'] ) && in_array( $badge['severity'], [ 'info', 'warning', 'success', 'error' ], true )
+				? (string) $badge['severity']
+				: 'info';
+			if ( '' === $id || '' === $message ) {
+				continue;
+			}
+			$normalised[] = [
+				'id'       => $id,
+				'message'  => $message,
+				'severity' => $severity,
+			];
+		}
+
+		return $normalised;
 	}
 
 	/**


### PR DESCRIPTION
Localise a new `consentAdminBadges` array onto `gtmkitSettings`, built from the new `gtmkit_consent_admin_badges` PHP filter. Add-ons that take over a piece of the consent surface (the Premium WP Consent API integration is the first, with named-CMP integrations to follow) push entries shaped as `[ id, message, severity ]` so the Consent settings page can render them as Notice banners at the top.

Each entry is normalised at the localise step: a missing id or message drops the badge before it reaches the React app, and severities outside the allowed `info|warning|success|error` set fall back to `info`. That keeps third-party additions from breaking the rendered output.

This is a passive surface — without any add-on hooked, the array is empty and the Consent page renders unchanged.

Changelog entry lands in a fresh Unreleased block in both changelog.txt and readme.txt, ready to be flipped into the next release's dated block by bin/change-version.sh.