### PR TITLE
Fix: silence PHP notices flagged by plugintests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** GTM Kit ***
 
+Unreleased
+* Fix: Silence the "translation loading triggered too early" notice that WordPress 6.7+ logs against the `gtm-kit` text domain by registering translations at the very start of `init` — before any other code can request a translated string.
+* Fix: Close an edge case where a script-dependency notice could still appear under WordPress 6.9.1+ when a consent or CMP plugin toggled the GTM Kit container active mid-request, by asking the WordPress script registry directly which scripts were actually registered instead of re-evaluating the container gate.
+
 2026-05-07 - version 2.10.1
 * Add: New `gtmkit_consent_admin_badges` filter lets add-ons (e.g. Premium's WP Consent API integration) push status banners onto the Consent settings page so users see immediately when a higher-priority consent source has taken over.
 

--- a/inc/main.php
+++ b/inc/main.php
@@ -218,7 +218,8 @@ if ( ! wp_installing() ) {
 		}
 	);
 
-	add_action( 'init', 'TLA_Media\GTM_Kit\gtmkit_load_text_domain' );
+	// Priority 0 so the textdomain is loaded before any other init callback that might call __() against it (WP 6.7+ warns when JIT loading triggers before init).
+	add_action( 'init', 'TLA_Media\GTM_Kit\gtmkit_load_text_domain', 0 );
 	if ( is_admin() ) {
 		add_action( 'plugins_loaded', 'TLA_Media\GTM_Kit\gtmkit_admin_init' );
 	} elseif ( ! wp_doing_ajax() ) {

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,12 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= Unreleased =
+
+#### Bugfixes:
+* Silence the "translation loading triggered too early" notice that WordPress 6.7+ logs against the `gtm-kit` text domain by registering translations at the very start of `init` — before any other code can request a translated string.
+* Close an edge case where a script-dependency notice could still appear under WordPress 6.9.1+ when a consent or CMP plugin toggled the GTM Kit container active mid-request, by asking the WordPress script registry directly which scripts were actually registered instead of re-evaluating the container gate.
+
 = 2.10.1 =
 
 Release date: 2026-05-07

--- a/src/Common/Util.php
+++ b/src/Common/Util.php
@@ -7,7 +7,6 @@
 
 namespace TLA_Media\GTM_Kit\Common;
 
-use TLA_Media\GTM_Kit\Frontend\Frontend;
 use TLA_Media\GTM_Kit\Integration\WooCommerce;
 use TLA_Media\GTM_Kit\Options\Options;
 
@@ -360,7 +359,8 @@ final class Util {
 
 		$deps[] = 'gtmkit';
 
-		if ( Frontend::will_register_container( $this->options ) ) {
+		// Ask the script registry whether `gtmkit-container` was actually registered earlier in this request rather than re-evaluating the gate predicate, which can disagree with the earlier evaluation if a `gtmkit_container_active` filter callback was added between `register()` and `wp_enqueue_scripts`.
+		if ( \wp_script_is( 'gtmkit-container', 'registered' ) ) {
 			$deps[] = 'gtmkit-container';
 		}
 

--- a/src/Frontend/Frontend.php
+++ b/src/Frontend/Frontend.php
@@ -291,7 +291,8 @@ final class Frontend {
 		$script  = 'const gtmkit_dataLayer_content = ' . wp_json_encode( $datalayer_data ) . ";\n";
 		$script .= esc_attr( $this->datalayer_name ) . '.push( gtmkit_dataLayer_content );' . "\n";
 
-		$dependency = self::will_register_container( $this->options ) ? [ 'gtmkit-container' ] : [ 'gtmkit' ];
+		// Ask the script registry whether `gtmkit-container` was actually registered earlier in this request rather than re-evaluating the gate predicate, which can disagree with the earlier evaluation if a `gtmkit_container_active` filter callback was added between `register()` and `wp_enqueue_scripts`.
+		$dependency = wp_script_is( 'gtmkit-container', 'registered' ) ? [ 'gtmkit-container' ] : [ 'gtmkit' ];
 
 		wp_register_script( 'gtmkit-datalayer', '', $dependency, GTMKIT_VERSION, [ 'in_footer' => false ] );
 		wp_enqueue_script( 'gtmkit-datalayer' );
@@ -409,7 +410,7 @@ final class Frontend {
 
 		$script = esc_attr( $this->datalayer_name ) . '.push({"event" : "load_delayed_js"});' . "\n";
 
-		$dependency = self::will_register_container( $this->options ) ? [ 'gtmkit-container' ] : [ 'gtmkit' ];
+		$dependency = wp_script_is( 'gtmkit-container', 'registered' ) ? [ 'gtmkit-container' ] : [ 'gtmkit' ];
 
 		wp_register_script( 'gtmkit-delay', '', $dependency, GTMKIT_VERSION, [ 'in_footer' => true ] );
 		wp_enqueue_script( 'gtmkit-delay' );

--- a/tests/phpunit/Integration/Bootstrap/TextDomainHookTest.php
+++ b/tests/phpunit/Integration/Bootstrap/TextDomainHookTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Integration test pinning the text-domain loader to `init` priority 0.
+ *
+ * WP 6.7+ logs a `_doing_it_wrong` notice when any `__()` against a
+ * text domain triggers JIT loading before `init` has fired. Hooking
+ * `gtmkit_load_text_domain` at the lowest priority on `init` is the
+ * regression guard — any `__()` call from a callback hooked at init
+ * priority 1+ finds the text domain already loaded and does not
+ * trigger JIT.
+ *
+ * Target: `add_action( 'init', 'TLA_Media\GTM_Kit\gtmkit_load_text_domain', 0 )`
+ * in `inc/main.php`.
+ *
+ * @package TLA_Media\GTM_Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Tests\Integration\Bootstrap;
+
+use WP_UnitTestCase;
+
+/**
+ * Pins the text-domain loader's hook priority.
+ */
+final class TextDomainHookTest extends WP_UnitTestCase {
+
+	/**
+	 * `gtmkit_load_text_domain` must be hooked at `init` priority 0.
+	 */
+	public function test_text_domain_loader_runs_at_init_priority_zero(): void {
+		$priority = has_action( 'init', 'TLA_Media\GTM_Kit\gtmkit_load_text_domain' );
+
+		$this->assertSame(
+			0,
+			$priority,
+			'gtmkit_load_text_domain must be hooked at init priority 0 so the text domain is registered before any other init callback can call __() against it.'
+		);
+	}
+}

--- a/tests/phpunit/Integration/Frontend/DataLayerDependencyTest.php
+++ b/tests/phpunit/Integration/Frontend/DataLayerDependencyTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Integration tests for the `gtmkit-datalayer` dependency-selection logic.
+ *
+ * Pattern: configure Options + filters, run the enqueue methods in the
+ * same order they fire under `wp_enqueue_scripts` (header script at
+ * priority 6, datalayer at priority 10), then read the registered
+ * dependency array from `wp_scripts()`.
+ *
+ * Regression target: WP 6.9.1+ logs a `WP_Scripts::add` notice when a
+ * script is enqueued with a dependency that was never registered. The
+ * old code re-evaluated the `gtmkit_container_active` filter inside
+ * `Frontend::will_register_container()` at priority 10, which could
+ * disagree with the earlier evaluation made at `register()` time and
+ * declare a dependency on `gtmkit-container` even when the header-script
+ * callback was never attached. The fix asks the script registry directly
+ * whether `gtmkit-container` was registered.
+ *
+ * Targets:
+ *
+ *  - {@see \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_datalayer_content}
+ *  - {@see \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_delay_js_script}
+ *
+ * @package TLA_Media\GTM_Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Tests\Integration\Frontend;
+
+use TLA_Media\GTM_Kit\Frontend\Frontend;
+use TLA_Media\GTM_Kit\Options\OptionsFactory;
+use WP_UnitTestCase;
+
+/**
+ * Covers the script-dependency selection for the dataLayer and delay-js handles.
+ */
+final class DataLayerDependencyTest extends WP_UnitTestCase {
+
+	/**
+	 * Reset the script registry and any filter callbacks so each test sees a clean slate.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		wp_cache_delete( 'gtmkit_script_settings', 'gtmkit' );
+		wp_scripts()->remove( 'gtmkit' );
+		wp_scripts()->remove( 'gtmkit-container' );
+		wp_scripts()->remove( 'gtmkit-datalayer' );
+		wp_scripts()->remove( 'gtmkit-delay' );
+		remove_all_filters( 'gtmkit_container_active' );
+
+		$options = OptionsFactory::get_instance();
+		$options->set_option( 'general', 'gtm_id', 'GTM-TEST123' );
+		$options->set_option( 'general', 'container_active', 1 );
+	}
+
+	/**
+	 * When the container script is registered, the datalayer depends on it.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_datalayer_content
+	 */
+	public function test_datalayer_depends_on_container_when_container_registered(): void {
+		$options  = OptionsFactory::get_instance();
+		$frontend = new Frontend( $options );
+
+		$frontend->enqueue_header_script();
+		$frontend->enqueue_datalayer_content();
+
+		$this->assertTrue( wp_script_is( 'gtmkit-container', 'registered' ) );
+		$this->assertSame(
+			[ 'gtmkit-container' ],
+			wp_scripts()->registered['gtmkit-datalayer']->deps,
+			'When gtmkit-container is registered, gtmkit-datalayer must depend on it.'
+		);
+	}
+
+	/**
+	 * When the container script is not registered, the datalayer falls back to `gtmkit`.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_datalayer_content
+	 */
+	public function test_datalayer_falls_back_when_container_not_registered(): void {
+		$options  = OptionsFactory::get_instance();
+		$frontend = new Frontend( $options );
+
+		// `enqueue_settings_and_data_script` registers `gtmkit` (priority 5),
+		// then we skip `enqueue_header_script` so `gtmkit-container` is not
+		// registered, then `enqueue_datalayer_content` runs (priority 10).
+		$frontend->enqueue_settings_and_data_script();
+		$frontend->enqueue_datalayer_content();
+
+		$this->assertFalse( wp_script_is( 'gtmkit-container', 'registered' ) );
+		$this->assertSame(
+			[ 'gtmkit' ],
+			wp_scripts()->registered['gtmkit-datalayer']->deps,
+			'When gtmkit-container is not registered, gtmkit-datalayer must fall back to depending on gtmkit.'
+		);
+	}
+
+	/**
+	 * Regression for the filter-race that caused the WP 6.9.1 dep warning: if
+	 * `gtmkit_container_active` was `false` at `register()` time (so the
+	 * priority-6 callback was never attached and `gtmkit-container` was never
+	 * registered) but flips to `true` by the time the datalayer dep predicate
+	 * is evaluated at priority 10, the dependency must still fall back to
+	 * `gtmkit` rather than naming the unregistered `gtmkit-container` handle.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_datalayer_content
+	 */
+	public function test_datalayer_falls_back_when_filter_flips_after_register(): void {
+		$options  = OptionsFactory::get_instance();
+		$frontend = new Frontend( $options );
+
+		// Simulate: at `register()` time, no `gtmkit_container_active`
+		// callback was attached and the priority-6 header-script callback
+		// never ran. A late callback then flips the predicate to true.
+		add_filter( 'gtmkit_container_active', '__return_true' );
+
+		$frontend->enqueue_settings_and_data_script();
+		$frontend->enqueue_datalayer_content();
+
+		$this->assertFalse( wp_script_is( 'gtmkit-container', 'registered' ) );
+		$this->assertSame(
+			[ 'gtmkit' ],
+			wp_scripts()->registered['gtmkit-datalayer']->deps,
+			'A late gtmkit_container_active=true filter must not produce a dependency on the unregistered gtmkit-container handle.'
+		);
+	}
+
+	/**
+	 * The same fall-back logic must also apply to the delay-js script.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::enqueue_delay_js_script
+	 */
+	public function test_delay_script_falls_back_when_container_not_registered(): void {
+		$options  = OptionsFactory::get_instance();
+		$frontend = new Frontend( $options );
+
+		add_filter( 'gtmkit_container_active', '__return_true' );
+
+		$frontend->enqueue_settings_and_data_script();
+		$frontend->enqueue_delay_js_script();
+
+		$this->assertFalse( wp_script_is( 'gtmkit-container', 'registered' ) );
+		$this->assertSame(
+			[ 'gtmkit' ],
+			wp_scripts()->registered['gtmkit-delay']->deps,
+			'gtmkit-delay must fall back to depending on gtmkit when gtmkit-container is not registered.'
+		);
+	}
+}


### PR DESCRIPTION
Two notices reported by plugintests when activating gtm-kit alongside add-ons against the latest WordPress + PHP:

1. WP 6.7+: "Translation loading for the gtm-kit domain was triggered too early." Hook the textdomain loader at init priority 0 so the domain is registered before any other init callback can request a translated string. Closes the JIT-loading race for our textdomain.

2. WP 6.9.1+: "The script with the handle 'gtmkit-datalayer' was enqueued with dependencies that are not registered: gtmkit-container." The 2.10.0 fix re-evaluated the gtmkit_container_active filter inside Frontend::will_register_container() at priority 10, which could disagree with the earlier evaluation made at register() time when a filter callback was added between plugins_loaded and wp_enqueue_scripts. Replace the dep predicate with wp_script_is( 'gtmkit-container', 'registered' ) so the dependency declaration asks the actual question ("was the script registered?") instead of re-deriving the answer from inputs that can shift mid-request. Applied at all three call sites: Frontend::enqueue_datalayer_content, Frontend::enqueue_delay_js_script, and Util::enqueue_script.

Tests:
- TextDomainHookTest pins the loader to init priority 0.
- DataLayerDependencyTest covers the gtmkit-container-present and gtmkit-container-absent paths plus the filter-flips-after-register regression that produced the 6.9.1 warning.