### PR TITLE
Fix: skip cookie keeper on WP-CLI to silence headers-sent warning

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** GTM Kit ***
 
 Unreleased
+* Fix: No more "headers already sent" PHP warning when running WP-CLI commands on sites that use the Cookie Keeper option.
 * Add: New welcome modal greets fresh installs on their first GTM Kit admin page and links to the documentation. Existing installs are not interrupted.
 * Add: GTM Kit can now surface launch and upgrade announcements from gtmkit.com without a plugin release.
 * Dev: New `gtmkit_introductions` filter and `Introduction_Interface` contract let add-ons register their own announcement modals via a documented public API.

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 * New welcome modal greets fresh installs on their first GTM Kit admin page and links to the documentation. Existing installs are not interrupted.
 * GTM Kit can now surface launch and upgrade announcements from gtmkit.com without a plugin release.
 
+#### Bugfixes:
+* No more "headers already sent" PHP warning when running WP-CLI commands on sites that use the Cookie Keeper option.
+
 #### Other:
 * New `gtmkit_introductions` filter and `Introduction_Interface` contract let add-ons register their own announcement modals through a documented public API.
 

--- a/src/Frontend/Stape.php
+++ b/src/Frontend/Stape.php
@@ -54,6 +54,10 @@ final class Stape {
 	 * @return void
 	 */
 	public function add_cookie_keeper() {
+		if ( ( defined( 'WP_CLI' ) && WP_CLI ) || headers_sent() ) {
+			return;
+		}
+
 		if ( ! $this->options->get( 'general', 'sgtm_cookie_keeper' ) ) {
 			if ( ! empty( $_COOKIE[ self::COOKIE_KEEPER_NAME ] ) ) {
 				$this->delete_cookie();


### PR DESCRIPTION
## Summary

Running any `wp` CLI command on a site with the **Cookie Keeper** option enabled produced:

```
Warning: Cannot modify header information - headers already sent by (output started at phar:///usr/local/bin/wp/vendor/react/promise/src/functions_include.php:4) in .../gtm-kit/src/Frontend/Stape.php on line 115
```

`Stape::add_cookie_keeper` runs on `init` and calls `setcookie()`. Under WP-CLI, stdout output from the WP-CLI phar's own autoload has already flushed before `init` fires, so emitting a `Set-Cookie` header trips PHP's `headers_sent()` guard and prints the warning. The cookie has no recipient in a CLI context anyway.

The fix is a one-liner at the top of `add_cookie_keeper`:

```php
if ( ( defined( 'WP_CLI' ) && WP_CLI ) || headers_sent() ) {
    return;
}
```

`headers_sent()` also covers the non-CLI edge case where another plugin emits output before `init`, so the warning is silenced everywhere it has nothing meaningful to do.

## Test plan

- [x] On a site with `general.sgtm_cookie_keeper = true`, run `wp option get blogname` and confirm no `Cannot modify header information` warning is printed.
- [x] Load a regular front-end page in the browser and confirm the `_sbp` cookie is still set on the first request and persists on subsequent ones.
- [x] Toggle Cookie Keeper off in the admin, reload the front end, and confirm the existing `_sbp` cookie is cleared.