### PR TITLE
Fix: guard WooCommerce loop tracking against null global $product

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** GTM Kit ***
 
 Unreleased
+* Fix: Prevent a fatal error on WooCommerce shop and archive pages when another plugin (e.g. WP Grid Builder) re-runs the product loop without a current product in context. GTM Kit now skips its hidden product-data tag instead of crashing the page.
 * Fix: No more "headers already sent" PHP warning when running WP-CLI commands on sites that use the Cookie Keeper option.
 * Add: New welcome modal greets fresh installs on their first GTM Kit admin page and links to the documentation. Existing installs are not interrupted.
 * Add: GTM Kit can now surface launch and upgrade announcements from gtmkit.com without a plugin release.

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 * GTM Kit can now surface launch and upgrade announcements from gtmkit.com without a plugin release.
 
 #### Bugfixes:
+* Prevent a fatal error on WooCommerce shop and archive pages when another plugin (e.g. WP Grid Builder) re-runs the product loop without a current product in context. GTM Kit now skips its hidden product-data tag instead of crashing the page.
 * No more "headers already sent" PHP warning when running WP-CLI commands on sites that use the Cookie Keeper option.
 
 #### Other:

--- a/src/Integration/WooCommerce.php
+++ b/src/Integration/WooCommerce.php
@@ -861,6 +861,10 @@ final class WooCommerce extends AbstractEcommerce {
 	public function single_product_add_to_cart_tracking(): void {
 		global $product;
 
+		if ( ! ( $product instanceof WC_Product ) ) {
+			return;
+		}
+
 		$item_data = $this->get_item_data( $product );
 
 		echo '<input type="hidden" name="gtmkit_product_data' . '" value="' . esc_attr( json_encode( $item_data ) ) . '" />' . "\n"; // phpcs:ignore
@@ -949,6 +953,10 @@ final class WooCommerce extends AbstractEcommerce {
 	 */
 	public function product_list_loop_add_to_cart_tracking(): void {
 		global $product, $woocommerce_loop;
+
+		if ( ! ( $product instanceof WC_Product ) ) {
+			return;
+		}
 
 		if ( ! empty( $woocommerce_loop['gtmkit_list_name'] ) ) {
 			$list_name = $woocommerce_loop['gtmkit_list_name'];


### PR DESCRIPTION
## Summary
- Some shop / archive renderers (e.g. WP Grid Builder's blocks integration, WooCommerce block templates re-running the loop) fire `woocommerce_after_shop_loop_item` and `woocommerce_after_add_to_cart_button` without populating `global $product`. The strict `WC_Product` type on `get_item_data_tag()` then threw a fatal `TypeError` and broke the page.
- Bail out of `product_list_loop_add_to_cart_tracking()` and `single_product_add_to_cart_tracking()` when `$product` is not a `WC_Product` instance, matching the defensive pattern already used by other handlers in `WooCommerce.php`.
- Reported on the WordPress.org support forum: https://wordpress.org/support/topic/fatal-error-with-wp-gruid-builder/

## Test plan
- [x] Reproduce on a site with WooCommerce + WP Grid Builder filtering the shop loop; confirm the shop page renders instead of throwing the fatal.
- [x] Smoke-test a normal WooCommerce shop and a single-product page: `view_item_list`, `select_item`, `view_item`, and `add_to_cart` still fire with the correct `item_list_name`.