### PR TITLE
Chore: cover QITStandard DebugFunctionFound on the WP_DEBUG-gated error_log

### DIFF
--- a/src/Admin/Introductions/Infrastructure/Remote_Introductions_Source.php
+++ b/src/Admin/Introductions/Infrastructure/Remote_Introductions_Source.php
@@ -268,6 +268,7 @@ final class Remote_Introductions_Source {
 			return;
 		}
 		$context = is_array( $entry ) ? \wp_json_encode( $entry ) : (string) $entry;
-		\error_log( '[gtm-kit] Remote_Introductions_Source dropped entry (' . $reason . '): ' . $context ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Developer-only debug surface, gated by WP_DEBUG.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log,QITStandard.PHP.DebugCode.DebugFunctionFound -- Developer-only debug surface, gated by WP_DEBUG.
+		\error_log( '[gtm-kit] Remote_Introductions_Source dropped entry (' . $reason . '): ' . $context );
 	}
 }


### PR DESCRIPTION
## Summary

`Remote_Introductions_Source::log_dropped()` writes to `error_log()` when `WP_DEBUG` is on, as a developer aid for diagnosing malformed remote-intro payloads. The line already suppresses `WordPress.PHP.DevelopmentFunctions.error_log_error_log` so PHPCS stays clean.

WooCommerce.com's QIT scan uses its own ruleset and flags the same call under `QITStandard.PHP.DebugCode.DebugFunctionFound`. It's a warning, not a release blocker, but it shows up on every Woo QIT report. Extending the existing `phpcs:ignore` to cover both rules clears the warning without changing runtime behaviour.

No changelog entry — pure lint suppression, no user- or integrator-visible change.