### PR TITLE
Fix WooCommerce QIT findings blocking the 2.13.0 submission

### DIFF
--- a/src/Admin/Suggestions.php
+++ b/src/Admin/Suggestions.php
@@ -345,6 +345,7 @@ final class Suggestions {
 	 */
 	protected function get_suggest_seo_plugin_notification( string $notification_id ): Notification {
 
+		// phpcs:ignore -- "Rank" here is part of the SEO plugin name "Rank Math" in a translatable UI string, not an SQL identifier; the marketplace SQL reserved-word scan false-positives on the word.
 		$message = __( 'It appears that you are not currently using a supported SEO plugin. By installing either WordPress SEO or Rank Math, you can assign a primary category to each product. This primary category will then be used in the data layer if the product is associated with multiple categories.', 'gtm-kit' );
 
 		return $this->new_notification(

--- a/src/Frontend/UrlExclusion.php
+++ b/src/Frontend/UrlExclusion.php
@@ -116,7 +116,7 @@ final class UrlExclusion {
 			}
 
 			if ( $result === false && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- intentional debug-mode signal for admins debugging a malformed pattern.
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log,QITStandard.PHP.DebugCode.DebugFunctionFound -- intentional debug-mode signal for admins debugging a malformed pattern.
 				error_log( sprintf( '[GTM Kit] URL exclusion pattern failed at runtime: %s', $pattern ) );
 			}
 		}
@@ -188,7 +188,7 @@ final class UrlExclusion {
 	 * @return string
 	 */
 	public static function current_request_path(): string {
-		$raw = isset( $_SERVER['REQUEST_URI'] ) ? (string) wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+		$raw = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		if ( $raw === '' ) {
 			return '/';
 		}


### PR DESCRIPTION
## Summary

Resolves the PHPCS findings the WooCommerce QIT scan raised while preparing the 2.13.0 marketplace submission. 2.13.0 is not tagged yet, so these fold into it (no version bump, no changelog change: pre-release compliance/hardening).

### `src/Frontend/UrlExclusion.php` (new 2.13.0 URL-exclusion feature)
- **Input sanitization:** `current_request_path()` now runs `$_SERVER['REQUEST_URI']` through `sanitize_text_field( wp_unslash() )` instead of a bare `(string)` cast, resolving `WordPress.Security.ValidatedSanitizedInput.InputNotSanitized`. The value only feeds path matching (via `wp_parse_url` then normalisation), so behaviour is unchanged for real request paths.
- **Debug-code sniff:** the existing `WP_DEBUG`-gated `error_log()` `phpcs:ignore` now also covers `QITStandard.PHP.DebugCode.DebugFunctionFound`, matching the annotation already used in `Remote_Introductions_Source`. The log line stays gated behind `WP_DEBUG`.

### `src/Admin/Suggestions.php`
- **SQL reserved-word false positive:** the marketplace SQL reserved-word scan flagged the word "Rank" inside a translatable UI string (the SEO plugin name "Rank Math") as an unquoted `rank` SQL identifier. There is no SQL in this file; backticking the word would corrupt a user-facing message. Suppressed with a line-scoped `phpcs:ignore` plus a rationale.

gtm-kit's own `composer phpcs` and `composer phpstan` stay green; UrlExclusion unit (16) and integration (5) tests pass.
