### PR TITLE
Release 2.13.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** GTM Kit ***
 
+2026-05-26 - version 2.13.1
+* Fix: The "Exclude pages from GTM" feature now also holds back the WooCommerce, Contact Form 7, and Easy Digital Downloads tracking scripts on excluded pages. Previously those add-on scripts could still load on an excluded page and fail, because the core GTM Kit runtime they rely on was withheld there.
+
 2026-05-26 - version 2.13.0
 * Add: New "Exclude pages from GTM" section on the Container settings page lets you list URL patterns where GTM Kit should stay off. Useful for third-party checkout iframes, partner-hosted subpages, or in-app webview routes that have their own tracking.
 * Add: New `window.gtmkit.events.push()` helper now sits in front of every GTM Kit event push, so an add-on can defer consent-sensitive events in the browser without server-side suppression.

--- a/gtm-kit.php
+++ b/gtm-kit.php
@@ -3,7 +3,7 @@
  * GTM Kit Plugin
  *
  * Plugin Name: GTM Kit
- * Version:     2.13.0
+ * Version:     2.13.1
  * Plugin URI:  https://gtmkit.com/
  * Description: Google Tag Manager implementation focusing on flexibility and pagespeed.
  * Author:      GTM Kit
@@ -27,7 +27,7 @@ if ( ! function_exists( 'add_filter' ) ) {
 	exit();
 }
 
-const GTMKIT_VERSION = '2.13.0';
+const GTMKIT_VERSION = '2.13.1';
 
 if ( ! defined( 'GTMKIT_FILE' ) ) {
 	define( 'GTMKIT_FILE', __FILE__ );

--- a/inc/main.php
+++ b/inc/main.php
@@ -137,18 +137,28 @@ function gtmkit_frontend_init(): void {
 
 	( new AdminAPI( $options, $util ) )->rest_init();
 
+	$output_gate = Frontend::resolve_output_gate( $options );
+
 	if ( ! $options->get( 'general', 'just_the_container' ) ) {
 		BasicDatalayerData::register( $options );
 		UserData::register( $options );
 
-		if ( $options->get( 'integrations', 'woocommerce_integration' ) && ( new WooCommerceConditional() )->is_met() ) {
-			WooCommerce::register( $options, $util );
-		}
-		if ( $options->get( 'integrations', 'cf7_integration' ) && ( new ContactForm7Conditional() )->is_met() ) {
-			ContactForm7::register( $options, $util );
-		}
-		if ( $options->get( 'integrations', 'edd_integration' ) && ( new EasyDigitalDownloadsConditional() )->is_met() ) {
-			EasyDigitalDownloads::register( $options, $util );
+		// Integrations enqueue their own gtmkit-dependent bundles and call the
+		// window.gtmkit runtime, so they must honor the same per-URL output
+		// gate as the core runtime. On an excluded URL with no filter override
+		// the gtmkit handle and its runtime are withheld, so registering an
+		// integration here would enqueue a script that depends on a handle that
+		// was never registered and calls a runtime that never loaded.
+		if ( ! Frontend::is_output_suppressed( $output_gate ) ) {
+			if ( $options->get( 'integrations', 'woocommerce_integration' ) && ( new WooCommerceConditional() )->is_met() ) {
+				WooCommerce::register( $options, $util );
+			}
+			if ( $options->get( 'integrations', 'cf7_integration' ) && ( new ContactForm7Conditional() )->is_met() ) {
+				ContactForm7::register( $options, $util );
+			}
+			if ( $options->get( 'integrations', 'edd_integration' ) && ( new EasyDigitalDownloadsConditional() )->is_met() ) {
+				EasyDigitalDownloads::register( $options, $util );
+			}
 		}
 	}
 
@@ -158,7 +168,7 @@ function gtmkit_frontend_init(): void {
 		Analytics::register( $options, $util );
 	}
 
-	Frontend::register( $options );
+	Frontend::register( $options, $output_gate );
 	require GTMKIT_PATH . 'inc/frontend-functions.php';
 }
 

--- a/languages/gtm-kit.pot
+++ b/languages/gtm-kit.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv3.
 msgid ""
 msgstr ""
-"Project-Id-Version: GTM Kit 2.13.0\n"
+"Project-Id-Version: GTM Kit 2.13.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/gtm-kit\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-25T13:21:02+00:00\n"
+"POT-Creation-Date: 2026-05-26T08:09:11+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.9.0\n"
 "X-Domain: gtm-kit\n"
@@ -153,77 +153,77 @@ msgstr ""
 msgid "Upgrade:"
 msgstr ""
 
-#: src/Admin/Suggestions.php:348
+#: src/Admin/Suggestions.php:349
 msgid "It appears that you are not currently using a supported SEO plugin. By installing either WordPress SEO or Rank Math, you can assign a primary category to each product. This primary category will then be used in the data layer if the product is associated with multiple categories."
 msgstr ""
 
-#: src/Admin/Suggestions.php:353
+#: src/Admin/Suggestions.php:354
 msgid "Plugin suggestion:"
 msgstr ""
 
 #. translators: %s is the name of the plugin.
-#: src/Admin/Suggestions.php:371
+#: src/Admin/Suggestions.php:372
 msgid "It seems that you have installed the Google Tag Manager plugin called %1$s. Running two different GTM plugins simultaneously can lead to unexpected results, significantly impact data accuracy, and slow down page speed. Please consider deactivating %2$s unless you have carefully considered and addressed the potential challenges."
 msgstr ""
 
-#: src/Admin/Suggestions.php:379
+#: src/Admin/Suggestions.php:380
 msgid "Possible Conflict:"
 msgstr ""
 
 #. translators: %1$s and %2$s are links with the text 'GTM Kit Woo Add-On' and 'Grandfathered Wishlist Functionality' respectively.
-#: src/Admin/Suggestions.php:400
+#: src/Admin/Suggestions.php:401
 msgid "Starting with GTM Kit version 2.0, the add_to_wishlist event is no longer supported in the free version of GTM Kit. To continue tracking the add_to_wishlist event, you must either purchase the %1$s or download the free %2$s plugin."
 msgstr ""
 
-#: src/Admin/Suggestions.php:408
+#: src/Admin/Suggestions.php:409
 msgid "Breaking change:"
 msgstr ""
 
-#: src/Admin/Suggestions.php:422
+#: src/Admin/Suggestions.php:423
 #: assets/admin/761.js:1
 #: assets/admin/837.js:1
 msgid "New releases of GTM Kit may contain important updates to comply with changes in Google Tag Manager or analytics in general. We recommend enabling automatic plugin updates for GTM Kit to ensure it is always up to date."
 msgstr ""
 
-#: src/Admin/Suggestions.php:426
-#: src/Admin/Suggestions.php:459
-#: src/Admin/Suggestions.php:493
+#: src/Admin/Suggestions.php:427
+#: src/Admin/Suggestions.php:460
+#: src/Admin/Suggestions.php:494
 msgid "Go to settings"
 msgstr ""
 
-#: src/Admin/Suggestions.php:432
+#: src/Admin/Suggestions.php:433
 msgid "Automatic Updates:"
 msgstr ""
 
-#: src/Admin/Suggestions.php:447
+#: src/Admin/Suggestions.php:448
 msgid "The Google Tag Manager container is not injected."
 msgstr ""
 
-#: src/Admin/Suggestions.php:450
+#: src/Admin/Suggestions.php:451
 msgid "The \"Inject Container Code\" option is not enabled."
 msgstr ""
 
-#: src/Admin/Suggestions.php:454
+#: src/Admin/Suggestions.php:455
 msgid "The \"GTM Container ID\" value is empty."
 msgstr ""
 
-#: src/Admin/Suggestions.php:465
+#: src/Admin/Suggestions.php:466
 msgid "GTM Container Injection:"
 msgstr ""
 
-#: src/Admin/Suggestions.php:481
+#: src/Admin/Suggestions.php:482
 msgid "Debug logging should not be active in production environments longer than necessary as it affects performance."
 msgstr ""
 
-#: src/Admin/Suggestions.php:484
+#: src/Admin/Suggestions.php:485
 msgid "The browser console log is active."
 msgstr ""
 
-#: src/Admin/Suggestions.php:488
+#: src/Admin/Suggestions.php:489
 msgid "The debug log for \"purchase\" events is active."
 msgstr ""
 
-#: src/Admin/Suggestions.php:499
+#: src/Admin/Suggestions.php:500
 msgid "Logging and debugging:"
 msgstr ""
 
@@ -876,7 +876,6 @@ msgid "User Data"
 msgstr ""
 
 #: assets/admin/389.js:1
-#: assets/admin/508.js:1
 #: assets/admin/523.js:1
 #: assets/admin/883.js:3
 msgid "Warning!"
@@ -1003,354 +1002,6 @@ msgstr ""
 msgid "Learn More"
 msgstr ""
 
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "Help finding GTM Container ID"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "Where to find your GTM Container ID"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "You can find your GTM Container ID in Google Tag Manager at the top of your workspace. It looks like GTM-XXXXXXX."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "GTM Container ID location in Google Tag Manager"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "Open Google Tag Manager"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Google Tag Manager container"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "General Container Settings"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "To start collecting data with Google Tag manager you must register the Container ID of your Google Tag Manager container."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "GTM Container ID:"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Enter GTM Container ID"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "Find your Container ID in Google Tag Manager"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Inject Container Code"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Setting this to Off will remove the Google Tag Manager container code but the data layer will remain."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Just the container"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Setting this to On will reduce the functionality to just the GTM container code. No additional data will be pushed to the datalayer regardless of any other settings."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "dataLayer variable name:"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "The default name of the data layer object is dataLayer. If you prefer to use a different name for your data layer, you may do so."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Server-side Tagging (sGTM)"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "sGTM Container Domain:"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Enter domain"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Enter your custom domain name if you are using a custom server side GTM container for tracking."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "sGTM container identifier:"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Enter loader name"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Only use if you are using a custom loader."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Cookie Keeper (for Stape users only)"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Prolong cookie lifetime in Safari and other browsers with ITP. This only works if you use Stape sGTM hosting and have set up the Cookie Keeper power up."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Google Tag Manager Server-side Tagging"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Server-side tagging is a silver bullet that gives you improved data accuracy, performance, privacy, and flexibility."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-#: assets/admin/690.js:19
-msgid "Learn more"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Hosting server-side GTM containers"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Setting up server-side tracking can be challenging and costly but there is an easy and cheap solution."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Stape.io is a solution for hosting server-side Google Tag Manager containers, offering a simplified approach that demands less technical expertise than solutions like Google Cloud Platform."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Additionally, it provides valuable add-ons for enhanced functionality."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Learn more about Stape.io"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Page Speed Optimization"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "load_delayed_js event"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Setting this to On will push the event 'load_delayed_js' on page load."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Delay JavaScript execution"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Page optimization plugins can delay the 'load_delayed_js' event and this can be used to delay the triggering og tags in Google Tag Manager."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Google Tag Manager Environment"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "gtm_auth:"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Enter gtm_auth code"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Enter the gtm_auth code for your GTM environment."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "gtm_preview:"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Enter gtm_preview code"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Enter the gtm_preview code for your GTM environment."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Environments"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "In Google Tag Manager you can define different environments like Live, Dev and QA."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "To use a specific environment in GTM Kit you must enter the \"gtm_auth\" and \"gtm_preview\" codes for that environment."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "If left empty the default environment will be used."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Override settings in wp-config.php"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "You can override the values by using constants in wp-config.php, which is a very useful for setting the value in your development and staging environments."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Exclude User Roles"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Exclude user roles"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Select the roles that you want to exclude from tracking."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Excluding user roles is not compatible with all full-page cache solutions. Some full-page cache solutions may cache the page identically for all users, regardless of their user role. This could result in users being excluded who should not be."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Please ensure thorough and proper testing of this."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Container Code Implementation"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Container code implementation:"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Standard implementation as recommended by Google (no delay)"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Load container when the browser is idle (requestIdleCallback)"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Depending on how you use Google Tag Manager you can delay the loading of the container script until the browser is idle."
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Container code noscript implementation:"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Just after the opening <body> tag"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Footer of the page (not recommended by Google)"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Custom (insert function in your template)"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "Disable <noscript> implementation"
-msgstr ""
-
-#: assets/admin/508.js:1
-#: assets/admin/523.js:1
-msgid "The preferred method to implement the <noscript> container code is just after the opening <body> tag. This requires that your theme uses the \"body_open\" hook. If your theme does not support this the script can be injected in the footer or you can use the function below."
-msgstr ""
-
 #: assets/admin/523.js:1
 msgid "No patterns configured. GTM Kit loads on every frontend page."
 msgstr ""
@@ -1396,6 +1047,81 @@ msgid "Maximum of 100 patterns reached."
 msgstr ""
 
 #: assets/admin/523.js:1
+#: assets/admin/767.js:1
+msgid "Help finding GTM Container ID"
+msgstr ""
+
+#: assets/admin/523.js:1
+#: assets/admin/767.js:1
+msgid "Where to find your GTM Container ID"
+msgstr ""
+
+#: assets/admin/523.js:1
+#: assets/admin/767.js:1
+msgid "You can find your GTM Container ID in Google Tag Manager at the top of your workspace. It looks like GTM-XXXXXXX."
+msgstr ""
+
+#: assets/admin/523.js:1
+#: assets/admin/767.js:1
+msgid "GTM Container ID location in Google Tag Manager"
+msgstr ""
+
+#: assets/admin/523.js:1
+#: assets/admin/767.js:1
+msgid "Open Google Tag Manager"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Google Tag Manager container"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "General Container Settings"
+msgstr ""
+
+#: assets/admin/523.js:1
+#: assets/admin/767.js:1
+msgid "To start collecting data with Google Tag manager you must register the Container ID of your Google Tag Manager container."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "GTM Container ID:"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Enter GTM Container ID"
+msgstr ""
+
+#: assets/admin/523.js:1
+#: assets/admin/767.js:1
+msgid "Find your Container ID in Google Tag Manager"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Inject Container Code"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Setting this to Off will remove the Google Tag Manager container code but the data layer will remain."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Just the container"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Setting this to On will reduce the functionality to just the GTM container code. No additional data will be pushed to the datalayer regardless of any other settings."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "dataLayer variable name:"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "The default name of the data layer object is dataLayer. If you prefer to use a different name for your data layer, you may do so."
+msgstr ""
+
+#: assets/admin/523.js:1
 msgid "Exclude pages from GTM"
 msgstr ""
 
@@ -1433,6 +1159,211 @@ msgstr ""
 
 #: assets/admin/523.js:1
 msgid "Regex mode: enter a raw PCRE pattern without delimiters. The matcher adds ~ delimiters and the i flag. Invalid patterns are rejected on save."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Server-side Tagging (sGTM)"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "sGTM Container Domain:"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Enter domain"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Enter your custom domain name if you are using a custom server side GTM container for tracking."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "sGTM container identifier:"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Enter loader name"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Only use if you are using a custom loader."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Cookie Keeper (for Stape users only)"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Prolong cookie lifetime in Safari and other browsers with ITP. This only works if you use Stape sGTM hosting and have set up the Cookie Keeper power up."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Google Tag Manager Server-side Tagging"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Server-side tagging is a silver bullet that gives you improved data accuracy, performance, privacy, and flexibility."
+msgstr ""
+
+#: assets/admin/523.js:1
+#: assets/admin/690.js:19
+msgid "Learn more"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Hosting server-side GTM containers"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Setting up server-side tracking can be challenging and costly but there is an easy and cheap solution."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Stape.io is a solution for hosting server-side Google Tag Manager containers, offering a simplified approach that demands less technical expertise than solutions like Google Cloud Platform."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Additionally, it provides valuable add-ons for enhanced functionality."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Learn more about Stape.io"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Page Speed Optimization"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "load_delayed_js event"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Setting this to On will push the event 'load_delayed_js' on page load."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Delay JavaScript execution"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Page optimization plugins can delay the 'load_delayed_js' event and this can be used to delay the triggering og tags in Google Tag Manager."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Google Tag Manager Environment"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "gtm_auth:"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Enter gtm_auth code"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Enter the gtm_auth code for your GTM environment."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "gtm_preview:"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Enter gtm_preview code"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Enter the gtm_preview code for your GTM environment."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Environments"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "In Google Tag Manager you can define different environments like Live, Dev and QA."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "To use a specific environment in GTM Kit you must enter the \"gtm_auth\" and \"gtm_preview\" codes for that environment."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "If left empty the default environment will be used."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Override settings in wp-config.php"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "You can override the values by using constants in wp-config.php, which is a very useful for setting the value in your development and staging environments."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Exclude User Roles"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Exclude user roles"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Select the roles that you want to exclude from tracking."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Excluding user roles is not compatible with all full-page cache solutions. Some full-page cache solutions may cache the page identically for all users, regardless of their user role. This could result in users being excluded who should not be."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Please ensure thorough and proper testing of this."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Container Code Implementation"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Container code implementation:"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Standard implementation as recommended by Google (no delay)"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Load container when the browser is idle (requestIdleCallback)"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Depending on how you use Google Tag Manager you can delay the loading of the container script until the browser is idle."
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Container code noscript implementation:"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Just after the opening <body> tag"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Footer of the page (not recommended by Google)"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Custom (insert function in your template)"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "Disable <noscript> implementation"
+msgstr ""
+
+#: assets/admin/523.js:1
+msgid "The preferred method to implement the <noscript> container code is just after the opening <body> tag. This requires that your theme uses the \"body_open\" hook. If your theme does not support this the script can be injected in the footer or you can use the function below."
 msgstr ""
 
 #: assets/admin/563.js:1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gtm-kit",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gtm-kit",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "dependencies": {
         "@wordpress/api-fetch": "^7.33.1",
         "@wordpress/components": "^30.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtm-kit",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Development files for the GTM Kit",
   "author": "GTM Kit",
   "keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://github.com/tlamedia/gtm-kit
 Tags: google tag manager, gtm, woocommerce, analytics, ga4
 Requires at least: 6.8
 Tested up to: 7.0
-Stable tag: 2.13.0
+Stable tag: 2.13.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -98,6 +98,15 @@ Yes! Pagespeed is one of our main focus points, and we strive to make the plugin
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/gtm-kit)
 
 == Changelog ==
+
+= 2.13.1 =
+
+Release date: 2026-05-26
+
+A maintenance fix for the 2.13 line; see the [2.13 release post](https://gtmkit.com/gtm-kit-2-13/) for what 2.13 introduced.
+
+#### Bugfixes:
+* The "Exclude pages from GTM" feature now also holds back the WooCommerce, Contact Form 7, and Easy Digital Downloads tracking scripts on excluded pages. Previously those add-on scripts could still load on an excluded page and fail, because the core GTM Kit runtime they rely on was withheld there.
 
 = 2.13.0 =
 

--- a/src/Frontend/Frontend.php
+++ b/src/Frontend/Frontend.php
@@ -67,27 +67,65 @@ final class Frontend {
 	}
 
 	/**
-	 * Register frontend
+	 * Resolve the per-request output gate.
+	 *
+	 * Computes the URL-exclusion state and the resulting container-active
+	 * value, applying the `gtmkit_container_active` filter exactly once so
+	 * the same decision can gate both the core runtime here and the
+	 * integration enqueues in `gtmkit_frontend_init()`.
 	 *
 	 * @param Options $options An instance of Options.
+	 * @return array{url_excluded: bool, container_active: bool}
 	 */
-	public static function register( Options $options ): void {
-		$page                    = new Frontend( $options );
-		$url_excluded            = UrlExclusion::is_excluded(
+	public static function resolve_output_gate( Options $options ): array {
+		$url_excluded     = UrlExclusion::is_excluded(
 			UrlExclusion::current_request_path(),
 			$options->get( 'general', 'excluded_url_patterns' )
 		);
-		$base_active             = ( $options->get( 'general', 'container_active' ) && ! $url_excluded );
-		$container_active        = (bool) apply_filters( 'gtmkit_container_active', $base_active );
+		$base_active      = ( $options->get( 'general', 'container_active' ) && ! $url_excluded );
+		$container_active = (bool) apply_filters( 'gtmkit_container_active', $base_active );
+
+		return [
+			'url_excluded'     => $url_excluded,
+			'container_active' => $container_active,
+		];
+	}
+
+	/**
+	 * Whether all GTM Kit frontend output is withheld for this request.
+	 *
+	 * True only when the URL matches an exclusion pattern and no
+	 * `gtmkit_container_active` filter forced the container back on. When
+	 * true, the core runtime and every integration enqueue must be skipped
+	 * so dependent scripts never reference a runtime that was never loaded.
+	 *
+	 * @param array{url_excluded: bool, container_active: bool} $gate Resolved output gate.
+	 * @return bool
+	 */
+	public static function is_output_suppressed( array $gate ): bool {
+		return ( $gate['url_excluded'] && ! $gate['container_active'] );
+	}
+
+	/**
+	 * Register frontend
+	 *
+	 * @param Options                                                $options An instance of Options.
+	 * @param array{url_excluded: bool, container_active: bool}|null $gate    Pre-resolved output gate; resolved here when null.
+	 */
+	public static function register( Options $options, ?array $gate = null ): void {
+		$page                    = new Frontend( $options );
+		$gate                    = $gate ?? self::resolve_output_gate( $options );
+		$container_active        = $gate['container_active'];
 		$noscript_implementation = $options->get( 'general', 'noscript_implementation' );
 
 		// On an excluded URL with no filter override, withhold every enqueue
 		// path together: head loader, noscript iframe, the dependent
 		// settings/data + dataLayer scripts, the delay-js push, the
 		// resource-hint DNS prefetch, and the cache-plugin attribute
-		// filters. The decision is per-URL and so safe to bake into the
-		// cached response.
-		if ( $url_excluded && ! $container_active ) {
+		// filters. Integration enqueues are withheld in tandem from
+		// gtmkit_frontend_init() using the same gate. The decision is
+		// per-URL and so safe to bake into the cached response.
+		if ( self::is_output_suppressed( $gate ) ) {
 			return;
 		}
 

--- a/tests/phpunit/Integration/Frontend/UrlExclusionGateTest.php
+++ b/tests/phpunit/Integration/Frontend/UrlExclusionGateTest.php
@@ -288,4 +288,88 @@ final class UrlExclusionGateTest extends WP_UnitTestCase {
 			'gtmkit_is_url_excluded=true must withhold gtmkit-container.'
 		);
 	}
+
+	/**
+	 * The shared output gate reports "not suppressed" on a normal URL, so
+	 * gtmkit_frontend_init() registers the integrations alongside the runtime.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::resolve_output_gate
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::is_output_suppressed
+	 */
+	public function test_output_gate_not_suppressed_on_normal_url(): void {
+		$_SERVER['REQUEST_URI'] = '/any-page';
+
+		$gate = Frontend::resolve_output_gate( OptionsFactory::get_instance() );
+
+		$this->assertFalse( $gate['url_excluded'], 'A normal URL is not excluded.' );
+		$this->assertTrue( $gate['container_active'], 'An active container stays active on a normal URL.' );
+		$this->assertFalse(
+			Frontend::is_output_suppressed( $gate ),
+			'Integrations must register on a non-excluded URL.'
+		);
+	}
+
+	/**
+	 * On an excluded URL the shared gate reports "suppressed", which is the
+	 * signal gtmkit_frontend_init() uses to skip the WooCommerce / CF7 / EDD
+	 * integration enqueues alongside the withheld core runtime.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::resolve_output_gate
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::is_output_suppressed
+	 */
+	public function test_output_gate_suppressed_on_excluded_url(): void {
+		$_SERVER['REQUEST_URI'] = '/checkout-embed/payment';
+		$options                = OptionsFactory::get_instance();
+		$options->set_option(
+			'general',
+			'excluded_url_patterns',
+			[
+				[
+					'pattern' => '/checkout-embed/*',
+					'mode'    => 'glob',
+				],
+			]
+		);
+
+		$gate = Frontend::resolve_output_gate( $options );
+
+		$this->assertTrue( $gate['url_excluded'], 'The configured pattern matches the request path.' );
+		$this->assertFalse( $gate['container_active'], 'An excluded URL deactivates the container.' );
+		$this->assertTrue(
+			Frontend::is_output_suppressed( $gate ),
+			'Integration enqueues must be skipped on an excluded URL.'
+		);
+	}
+
+	/**
+	 * A `gtmkit_container_active` override on an excluded URL flips the gate
+	 * back to "not suppressed", so the integrations register again in tandem
+	 * with the core runtime.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::resolve_output_gate
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::is_output_suppressed
+	 */
+	public function test_output_gate_override_keeps_integrations_on_excluded_url(): void {
+		$_SERVER['REQUEST_URI'] = '/checkout-embed/payment';
+		$options                = OptionsFactory::get_instance();
+		$options->set_option(
+			'general',
+			'excluded_url_patterns',
+			[
+				[
+					'pattern' => '/checkout-embed/*',
+					'mode'    => 'glob',
+				],
+			]
+		);
+		add_filter( 'gtmkit_container_active', '__return_true' );
+
+		$gate = Frontend::resolve_output_gate( $options );
+
+		$this->assertTrue( $gate['container_active'], 'The override forces the container active.' );
+		$this->assertFalse(
+			Frontend::is_output_suppressed( $gate ),
+			'An override that re-enables the container must also re-enable integrations.'
+		);
+	}
 }

--- a/tests/phpunit/Unit/Frontend/FrontendOutputGateTest.php
+++ b/tests/phpunit/Unit/Frontend/FrontendOutputGateTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Unit tests for the Frontend output-gate decision.
+ *
+ * Exercises {@see \TLA_Media\GTM_Kit\Frontend\Frontend::is_output_suppressed()},
+ * the pure predicate that gtmkit_frontend_init() and Frontend::register() share
+ * to decide whether every GTM Kit enqueue (core runtime and integrations) is
+ * withheld for the current request.
+ *
+ * @package TLA_Media\GTM_Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Tests\Unit\Frontend;
+
+use TLA_Media\GTM_Kit\Frontend\Frontend;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * Unit tests for {@see Frontend::is_output_suppressed()}.
+ */
+final class FrontendOutputGateTest extends TestCase {
+
+	/**
+	 * Output is suppressed only when the URL is excluded and the container is
+	 * not forced back on.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::is_output_suppressed
+	 */
+	public function test_suppressed_only_when_excluded_and_container_inactive(): void {
+		$this->assertTrue(
+			Frontend::is_output_suppressed(
+				[
+					'url_excluded'     => true,
+					'container_active' => false,
+				]
+			),
+			'An excluded URL with no override must suppress all output.'
+		);
+	}
+
+	/**
+	 * A `gtmkit_container_active` override keeps output on even for an excluded
+	 * URL.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::is_output_suppressed
+	 */
+	public function test_not_suppressed_when_override_forces_container_on(): void {
+		$this->assertFalse(
+			Frontend::is_output_suppressed(
+				[
+					'url_excluded'     => true,
+					'container_active' => true,
+				]
+			),
+			'A filter that forces the container on must keep output enabled.'
+		);
+	}
+
+	/**
+	 * A non-excluded URL is never suppressed by this gate, even when the
+	 * container is inactive for other reasons.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Frontend\Frontend::is_output_suppressed
+	 */
+	public function test_not_suppressed_when_url_not_excluded(): void {
+		$this->assertFalse(
+			Frontend::is_output_suppressed(
+				[
+					'url_excluded'     => false,
+					'container_active' => true,
+				]
+			),
+			'A non-excluded URL with an active container is not suppressed.'
+		);
+
+		$this->assertFalse(
+			Frontend::is_output_suppressed(
+				[
+					'url_excluded'     => false,
+					'container_active' => false,
+				]
+			),
+			'A globally inactive container on a non-excluded URL is a separate path, not exclusion suppression.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Patches gtm-kit 2.13.0. Fixes a High-severity bug in the new "Exclude pages from GTM" feature: on an excluded URL it withheld only the core GTM Kit runtime, not the WooCommerce / Contact Form 7 / Easy Digital Downloads integrations.

On an excluded page where an integration condition is met (most importantly an excluded checkout, the feature's headline use case), the integration still enqueued a script depending on the unregistered `gtmkit` handle and called the withheld `window.gtmkit.events.push` runtime, producing a WordPress dependency warning and a JavaScript error.

Reported via review on the 2.13.0 release commit (thanks @szepeviktor).

### Fix
- New `Frontend::resolve_output_gate()` computes the URL-exclusion / container-active decision once (firing `gtmkit_container_active` a single time); `Frontend::is_output_suppressed()` reduces it to a boolean.
- `gtmkit_frontend_init()` resolves the gate up front and skips the integration registrations when output is suppressed, in tandem with the core runtime. `Frontend::register()` reuses the same gate.
- A `gtmkit_container_active` override that forces the container back on still re-enables the integrations.

### Tests
- Unit: `is_output_suppressed()` truth table.
- Integration: `resolve_output_gate()` across the normal, excluded, and override paths (the exact decision the bootstrap uses to gate integrations).

### Release mechanics
- Version bumped to 2.13.1: gtm-kit.php, readme.txt (Stable tag), package.json, package-lock.json.
- changelog.txt + readme.txt gain the 2.13.1 Fix entry. The `= 2.13.1 =` block links to the 2.13 release post (`gtmkit.com/gtm-kit-2-13/`), following the 2.10.1 patch precedent. Say so if you'd rather point elsewhere.
- languages/gtm-kit.pot regenerated (Project-Id-Version: GTM Kit 2.13.1). The large line diff is entry reorder + source line-reference churn only; the msgid count is unchanged (517).
- No asset or autoload changes: PHP-only fix, no JS changed, no new classes.

## Quality gates
- [x] composer phpstan: 0 errors
- [x] composer phpcs: 0 errors, 0 warnings
- [x] PHPUnit unit + integration: 65 + 90 pass (1 expected skip)
- [x] Vitest: 35/35 pass
