### PR TITLE
Add `gtmkit_loaded` action hook for add-on bootstrapping

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** GTM Kit ***
 
+Unreleased
+* Dev: New `gtmkit_loaded` action hook fires once GTM Kit core has finished loading, giving add-ons and integrations a reliable point to bootstrap against the active GTM Kit instead of depending on plugin load order.
+
 2026-05-26 - version 2.13.1
 * Fix: The "Exclude pages from GTM" feature now also holds back the WooCommerce, Contact Form 7, and Easy Digital Downloads tracking scripts on excluded pages. Previously those add-on scripts could still load on an excluded page and fail, because the core GTM Kit runtime they rely on was withheld there.
 

--- a/inc/main.php
+++ b/inc/main.php
@@ -237,4 +237,17 @@ if ( ! wp_installing() ) {
 	} elseif ( ! wp_doing_ajax() ) {
 		add_action( 'plugins_loaded', 'TLA_Media\GTM_Kit\gtmkit_frontend_init' );
 	}
+
+	// Signal that the core plugin is loaded and its autoloader, classes and
+	// services are available. Add-ons hook this to boot themselves, so they bind
+	// to the active core deterministically instead of racing on plugins_loaded.
+	// Priority 11 runs after the core init callbacks registered above (default
+	// priority 10).
+	add_action(
+		'plugins_loaded',
+		static function (): void {
+			do_action( 'gtmkit_loaded' );
+		},
+		11
+	);
 }

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,11 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= Unreleased =
+
+#### Other:
+* New `gtmkit_loaded` action hook fires once GTM Kit core has finished loading, giving add-ons and integrations a reliable point to bootstrap against the active GTM Kit.
+
 = 2.13.1 =
 
 Release date: 2026-05-26


### PR DESCRIPTION
## Summary

Adds a `gtmkit_loaded` action hook that fires once GTM Kit core has finished loading — on `plugins_loaded` priority 11, after GTM Kit's own admin/front-end init. It gives add-ons and integrations a deterministic point to run their own bootstrap against the active GTM Kit, instead of depending on plugin load order.

The change is purely additive: a single new `do_action( 'gtmkit_loaded' )`. No existing behaviour changes.

## Test plan

- [x] With GTM Kit active, confirm a callback registered via `add_action( 'gtmkit_loaded', ... )` runs on a normal front-end request and on an admin request.
- [x] Confirm the GTM container still loads and `window.dataLayer` is populated as before (no regression).