### PR TITLE
Remove the unused `gtmkit_loaded` action hook

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,5 @@
 *** GTM Kit ***
 
-Unreleased
-* Dev: New `gtmkit_loaded` action hook fires once GTM Kit core has finished loading, giving add-ons and integrations a reliable point to bootstrap against the active GTM Kit instead of depending on plugin load order.
-
 2026-05-26 - version 2.13.1
 * Fix: The "Exclude pages from GTM" feature now also holds back the WooCommerce, Contact Form 7, and Easy Digital Downloads tracking scripts on excluded pages. Previously those add-on scripts could still load on an excluded page and fail, because the core GTM Kit runtime they rely on was withheld there.
 

--- a/inc/main.php
+++ b/inc/main.php
@@ -237,17 +237,4 @@ if ( ! wp_installing() ) {
 	} elseif ( ! wp_doing_ajax() ) {
 		add_action( 'plugins_loaded', 'TLA_Media\GTM_Kit\gtmkit_frontend_init' );
 	}
-
-	// Signal that the core plugin is loaded and its autoloader, classes and
-	// services are available. Add-ons hook this to boot themselves, so they bind
-	// to the active core deterministically instead of racing on plugins_loaded.
-	// Priority 11 runs after the core init callbacks registered above (default
-	// priority 10).
-	add_action(
-		'plugins_loaded',
-		static function (): void {
-			do_action( 'gtmkit_loaded' );
-		},
-		11
-	);
 }

--- a/readme.txt
+++ b/readme.txt
@@ -99,11 +99,6 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= Unreleased =
-
-#### Other:
-* New `gtmkit_loaded` action hook fires once GTM Kit core has finished loading, giving add-ons and integrations a reliable point to bootstrap against the active GTM Kit.
-
 = 2.13.1 =
 
 Release date: 2026-05-26


### PR DESCRIPTION
## Summary

Removes the `gtmkit_loaded` action hook. It was added for the Woo and Premium add-ons to defer their bootstrap, but they bind to the active core through their Composer autoloader and load on their existing `plugins_loaded` hooks instead — nothing consumes `gtmkit_loaded`. This reverts the commit that introduced it (code plus the unreleased changelog/readme entries), so it doesn't ship as an orphaned public action.

The hook only ever existed in the `Unreleased` block, so there is no released-behaviour change.

## Test plan

- [x] GTM Kit activates and a front-end page still outputs the container and a populated `window.dataLayer` (no regression from removing the hook).