### PR TITLE
Fix Contact Form 7 integration enqueue on cache-deferred installs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** GTM Kit ***
 
 Unreleased
+* Fix: The Contact Form 7 integration now loads reliably on form pages when "Load JavaScript" is set to the recommended "Only on pages where the Contact Form 7 script is registered" mode, even when a performance plugin (e.g. WP Rocket) defers Contact Form 7's own scripts until shortcode render. Previously the integration could be skipped on legitimate form pages and `gtmkit.CF7MailSent` would not fire.
 * Add: New "Engagement events" settings section emits GA4 standard `login`, `sign_up`, `search`, and `generate_lead` events out of the box. Each event has its own toggle and defaults to on, so customers see the events the moment they upgrade.
 * Add: New developer filters let extensions tag the method (`gtmkit_engagement_event_login_method`, `gtmkit_engagement_event_signup_method`), normalise the search term (`gtmkit_engagement_event_search_term`), assign a lead value (`gtmkit_engagement_event_generate_lead_payload`), rename the handoff cookie (`gtmkit_engagement_event_cookie_name`), veto any event (`gtmkit_engagement_event_should_emit`), or opt custom search templates into the `search` event (`gtmkit_is_search_results_page`).
 * Dev: Prepare the settings and setup-wizard bootstrap for React 19, which WordPress will ship in a future release. No behaviour change under the current React 18.

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 #### New:
 * New "Engagement events" settings section emits GA4 standard `login`, `sign_up`, `search`, and `generate_lead` events out of the box. Each event has its own toggle and defaults to on, so customers see the events the moment they upgrade.
 
+#### Bugfixes:
+* The Contact Form 7 integration now loads reliably on form pages when "Load JavaScript" is set to the recommended "Only on pages where the Contact Form 7 script is registered" mode, even when a performance plugin (e.g. WP Rocket) defers Contact Form 7's own scripts until shortcode render. Previously the integration could be skipped on legitimate form pages and `gtmkit.CF7MailSent` would not fire.
+
 #### Other:
 * New developer filters let extensions tag the method, normalise the search term, assign a lead value, rename the handoff cookie, veto any event, or opt custom search templates into the `search` event.
 * Prepare the settings and setup-wizard bootstrap for React 19, which WordPress will ship in a future release. No behaviour change under the current React 18.

--- a/src/Integration/ContactForm7.php
+++ b/src/Integration/ContactForm7.php
@@ -17,6 +17,15 @@ use TLA_Media\GTM_Kit\Options\Options;
 final class ContactForm7 extends AbstractIntegration {
 
 	/**
+	 * "Load JavaScript" setting value for the "on all pages" mode.
+	 * The recommended mode is `1` and falls through any non-`2`
+	 * value, so only the all-pages path needs a named constant.
+	 *
+	 * @var int
+	 */
+	private const LOAD_JS_ALL_PAGES = 2;
+
+	/**
 	 * Instance.
 	 *
 	 * @var null|ContactForm7 An instance of ContactForm7.
@@ -40,6 +49,18 @@ final class ContactForm7 extends AbstractIntegration {
 	/**
 	 * Register frontend
 	 *
+	 * The recommended "only on pages where CF7 is registered" mode
+	 * hooks into the `wpcf7_enqueue_scripts` action that Contact Form
+	 * 7 fires from inside its own enqueue path. That action is
+	 * invoked from both the standard `wp_enqueue_scripts` flow and
+	 * the late shortcode-time enqueue used by performance plugins
+	 * (e.g. WP Rocket sets `wpcf7_load_js` to false so CF7 only loads
+	 * during shortcode render). Using the action means our integration
+	 * script lands on every page where CF7's own script lands, with
+	 * no false negatives from `wp_script_is()` running before CF7 has
+	 * decided to enqueue. The "on all pages" mode keeps the direct
+	 * `wp_enqueue_scripts` hook so the integration loads unconditionally.
+	 *
 	 * @param Options $options An instance of Options.
 	 * @param Util    $util An instance of Util.
 	 */
@@ -47,17 +68,27 @@ final class ContactForm7 extends AbstractIntegration {
 
 		self::$instance = new self( $options, $util );
 
-		add_action( 'wp_enqueue_scripts', [ self::$instance, 'enqueue_scripts' ] );
+		$mode = (int) $options->get( 'integrations', 'cf7_load_js' );
+
+		if ( self::LOAD_JS_ALL_PAGES === $mode ) {
+			add_action( 'wp_enqueue_scripts', [ self::$instance, 'enqueue_scripts' ] );
+			return;
+		}
+
+		add_action( 'wpcf7_enqueue_scripts', [ self::$instance, 'enqueue_scripts' ] );
 	}
 
 	/**
-	 * Enqueue scripts
+	 * Enqueue scripts.
+	 *
+	 * Runs from one of two hooks depending on the "Load JavaScript"
+	 * setting; both reach the same handle + localized config. The
+	 * hook-level gating in {@see self::register()} replaces the old
+	 * inline `wp_script_is()` check, which produced false negatives on
+	 * pages where CF7 enqueues later than `wp_enqueue_scripts` priority 10.
 	 */
 	public function enqueue_scripts(): void {
 
-		if ( (int) $this->options->get( 'integrations', 'cf7_load_js' ) === 1 && ! wp_script_is( 'contact-form-7' ) ) {
-			return;
-		}
 		$this->util->enqueue_script( 'gtmkit-cf7', 'integration/contact-form-7.js' );
 
 		// Hand the CF7 module the generate_lead toggle + an optional

--- a/tests/phpunit/Unit/Integration/ContactForm7Test.php
+++ b/tests/phpunit/Unit/Integration/ContactForm7Test.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Unit tests for the Contact Form 7 integration's hook-registration
+ * behaviour.
+ *
+ * The integration ships a "Load JavaScript" setting with two modes:
+ *
+ *  - `1` — "Only on pages where the Contact Form 7 script is registered
+ *    (recommended)". Hooks into the `wpcf7_enqueue_scripts` action
+ *    Contact Form 7 fires from inside its own enqueue path, so the
+ *    integration script lands whether CF7 enqueued the normal way
+ *    (during `wp_enqueue_scripts`) or the late way (during shortcode
+ *    render, used by performance plugins like WP Rocket that filter
+ *    `wpcf7_load_js` to false).
+ *  - `2` — "On all pages". Hooks `wp_enqueue_scripts` directly so the
+ *    integration loads unconditionally.
+ *
+ * These tests assert the hook wiring picked by each mode.
+ *
+ * @package TLA_Media\GTM_Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Tests\Unit\Integration;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use TLA_Media\GTM_Kit\Common\RestAPIServer;
+use TLA_Media\GTM_Kit\Common\Util;
+use TLA_Media\GTM_Kit\Integration\ContactForm7;
+use TLA_Media\GTM_Kit\Options\Options;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * Unit tests for {@see ContactForm7::register()}.
+ */
+final class ContactForm7Test extends TestCase {
+
+	/**
+	 * Stub `get_option` so the in-memory `Options` instance returns
+	 * the supplied `cf7_load_js` value.
+	 *
+	 * @param int $cf7_load_js Setting value to read back.
+	 */
+	private function stub_options_with_load_mode( int $cf7_load_js ): void {
+		Functions\stubs(
+			[
+				'get_option'        => [
+					'integrations' => [
+						'cf7_load_js' => $cf7_load_js,
+					],
+				],
+				'add_filter'        => null,
+				// Stubbed so `Util::load_plugin_api()` short-circuits
+				// without trying to require `wp-admin/includes/plugin.php`,
+				// which is unavailable in the unit harness.
+				'is_plugin_active'  => false,
+				'wp_normalize_path' => static fn( $path ) => $path,
+			]
+		);
+	}
+
+	/**
+	 * Build a `Util` instance against the stubbed options.
+	 *
+	 * @return array{0: Options, 1: Util}
+	 */
+	private function dependencies(): array {
+		if ( ! defined( 'GTMKIT_PATH' ) ) {
+			define( 'GTMKIT_PATH', '/fake/plugin/path/' );
+		}
+		if ( ! defined( 'GTMKIT_URL' ) ) {
+			define( 'GTMKIT_URL', 'https://example.test/wp-content/plugins/gtm-kit/' );
+		}
+
+		$options = Options::create();
+		$util    = new Util( $options, new RestAPIServer() );
+
+		return [ $options, $util ];
+	}
+
+	/**
+	 * The recommended mode (`cf7_load_js = 1`) attaches to
+	 * `wpcf7_enqueue_scripts` so the integration loads whenever CF7
+	 * actually enqueues, including the late shortcode-time path used
+	 * by WP Rocket.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Integration\ContactForm7::register
+	 */
+	public function test_recommended_mode_hooks_wpcf7_enqueue_scripts(): void {
+		$this->stub_options_with_load_mode( 1 );
+		[ $options, $util ] = $this->dependencies();
+
+		Actions\expectAdded( 'wpcf7_enqueue_scripts' )->once();
+
+		ContactForm7::register( $options, $util );
+
+		self::assertTrue( true ); // assertion is the action expectation above.
+	}
+
+	/**
+	 * The "On all pages" mode (`cf7_load_js = 2`) attaches directly
+	 * to `wp_enqueue_scripts` so the integration loads on every
+	 * frontend request.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Integration\ContactForm7::register
+	 */
+	public function test_all_pages_mode_hooks_wp_enqueue_scripts(): void {
+		$this->stub_options_with_load_mode( 2 );
+		[ $options, $util ] = $this->dependencies();
+
+		Actions\expectAdded( 'wp_enqueue_scripts' )->once();
+
+		ContactForm7::register( $options, $util );
+
+		self::assertTrue( true ); // assertion is the action expectation above.
+	}
+
+	/**
+	 * An unrecognised mode value falls through to the recommended
+	 * path so misconfigured installs still receive the integration
+	 * via the action route.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Integration\ContactForm7::register
+	 */
+	public function test_unknown_mode_falls_back_to_recommended(): void {
+		$this->stub_options_with_load_mode( 99 );
+		[ $options, $util ] = $this->dependencies();
+
+		Actions\expectAdded( 'wpcf7_enqueue_scripts' )->once();
+
+		ContactForm7::register( $options, $util );
+
+		self::assertTrue( true ); // assertion is the action expectation above.
+	}
+}


### PR DESCRIPTION
## What

Hooks the GTM Kit Contact Form 7 integration into CF7's own `wpcf7_enqueue_scripts` action when "Load JavaScript" is set to the recommended **"Only on pages where the Contact Form 7 script is registered"** mode. Drops the inline `wp_script_is( 'contact-form-7' )` guard that was the source of the bug.

## Why

WP Rocket (and other performance plugins, per CF7's own third-party docs) filter `wpcf7_load_js` to `__return_false` so CF7 doesn't enqueue its main script during `wp_enqueue_scripts` at all — it enqueues lazily when a `[contact-form-7]` shortcode is rendered. The previous guard ran at `wp_enqueue_scripts` priority 10 and called `wp_script_is( 'contact-form-7' )`, which returned false on every page (including legitimate form pages). The integration script was silently skipped and the long-standing `gtmkit.CF7MailSent` event stopped firing for affected sites. The new `generate_lead` event added in #753 silently broke for the same reason.

CF7 fires `do_action( 'wpcf7_enqueue_scripts' )` from inside its enqueue function regardless of whether it ran from `wp_enqueue_scripts` or from the shortcode-render fallback that WP Rocket's third-party module triggers. Listening for that action means we land on every page where CF7 itself lands, with no false negatives.

## Behaviour

| Mode | Old behaviour | New behaviour |
|---|---|---|
| 1 — Only on CF7 pages (recommended) | Skipped when CF7 enqueued late (WP Rocket, lazy loaders) | Hooks `wpcf7_enqueue_scripts`; loads whenever CF7's script loads |
| 2 — On all pages | Loads on every frontend page | Unchanged |

## Test plan

- With "Load JavaScript" = mode 1 and a CF7 form page (`/cf7/`):
  `Array.from(document.scripts).map(s => s.src).filter(s => s.includes('gtm-kit') && s.includes('contact-form-7'))` returns the integration script URL.
- Submitting the form pushes `gtmkit.CF7MailSent` then `generate_lead`, in that order.
- With mode 1 and a non-CF7 page (`/`): the integration script is **not** enqueued.
- With mode 2: integration loads on every page (existing behaviour preserved).

All four checks confirmed on a local install with WP Rocket active and CF7 6.1.6.