### PR TITLE
Exclude .wp-env.json from the distributed plugin

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -12,6 +12,7 @@
 .distignore
 .editorconfig
 .gitignore
+.wp-env.json
 composer.json
 composer.lock
 package.json


### PR DESCRIPTION
The `.wp-env.json` added for the WooCommerce block E2E harness is a dev-only file. It was not matched by any existing `.distignore` pattern, so it would be bundled into the plugin ZIP. Add it to `.distignore`.

The block E2E test directories and JS sources are already excluded via the existing `/tests` and `/src/js` patterns; `.wp-env.json` was the only gap.

No runtime impact.