### PR TITLE
Fix: detect WooCommerce blocks rendered from FSE templates and routes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** GTM Kit ***
 
+Unreleased
+* Fix: WooCommerce block tracking now loads on block (FSE) themes where Cart, Checkout, Mini Cart, Product Collection, or Related Products are rendered from block templates and template parts. Previously the block tracking bundle could fail to load on these sites, so block ecommerce events never fired.
+
 2026-06-02 - version 2.14.0
 * Fix: The Contact Form 7 integration now loads reliably on form pages when "Load JavaScript" is set to the recommended "Only on pages where the Contact Form 7 script is registered" mode, even when a performance plugin (e.g. WP Rocket) defers Contact Form 7's own scripts until shortcode render. Previously the integration could be skipped on legitimate form pages and `gtmkit.CF7MailSent` would not fire.
 * Add: New "Engagement events" settings section emits GA4 standard `login`, `sign_up`, `search`, and `generate_lead` events out of the box. Each event has its own toggle and defaults to on, so customers see the events the moment they upgrade.

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,11 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= Unreleased =
+
+#### Bugfixes:
+* WooCommerce block tracking now loads on block (FSE) themes where Cart, Checkout, Mini Cart, Product Collection, or Related Products are rendered from block templates and template parts. Previously the block tracking bundle could fail to load on these sites, so block ecommerce events never fired.
+
 = 2.14.0 =
 
 Release date: 2026-06-02

--- a/src/Integration/WooCommerceBlocks.php
+++ b/src/Integration/WooCommerceBlocks.php
@@ -69,6 +69,15 @@ final class WooCommerceBlocks {
 	private WooCommerce $woocommerce;
 
 	/**
+	 * Resolved header/footer template-part contents, memoized per request.
+	 *
+	 * Null until the first template-part scan resolves them.
+	 *
+	 * @var array<int, string>|null
+	 */
+	private ?array $template_part_contents = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param Options     $options An instance of Options.
@@ -176,67 +185,279 @@ final class WooCommerceBlocks {
 
 	/**
 	 * Whether the current page renders any supported block.
+	 *
+	 * On block (FSE) themes WooCommerce renders Cart, Checkout, Mini Cart,
+	 * Product Collection and Related Products from block templates and
+	 * template parts rather than post content, so a post-content-only check
+	 * misses them. Detection is therefore layered, cheapest-first with
+	 * short-circuit:
+	 *
+	 * 1. Post content: `has_block()` (also matches blocks nested in
+	 *    Group/Columns/Query wrappers) plus the product-filter family.
+	 * 2. WooCommerce route safety net: the canonical Cart/Checkout/shop/
+	 *    product/taxonomy routes, which is what reliably covers FSE
+	 *    storefronts including archives that have no post ID.
+	 * 3. Site-wide header/footer template parts (block themes only), where
+	 *    the Mini Cart (and any supported block) is typically placed.
 	 */
 	public function page_has_supported_blocks(): bool {
 
-		foreach ( $this->get_supported_blocks() as $block_name ) {
-			if ( 'woocommerce/mini-cart' === $block_name ) {
-				if ( $this->has_mini_cart() ) {
-					return true;
-				}
-				continue;
-			}
+		$supported = $this->get_supported_blocks();
 
+		foreach ( $supported as $block_name ) {
 			if ( has_block( $block_name ) ) {
 				return true;
 			}
 		}
 
-		return $this->has_filter_block();
+		if ( $this->has_filter_block() ) {
+			return true;
+		}
+
+		if ( $this->is_woocommerce_route() ) {
+			return true;
+		}
+
+		return $this->has_supported_block_in_template_parts( $supported );
 	}
 
 	/**
 	 * Whether the current page renders the Cart or Checkout block.
+	 *
+	 * Block-built (FSE) Cart/Checkout must be distinguished from the classic
+	 * shortcode/legacy variants: only on the former should the block bundle
+	 * take over and the classic scripts step aside. The route conditionals
+	 * (`is_cart()`/`is_checkout()`) are true for both, so they cannot tell
+	 * them apart. Instead, read the configured Cart/Checkout page's content:
+	 * on a block-built store WooCommerce stores the Cart/Checkout block there
+	 * (regardless of theme), while a classic store stores the shortcode. This
+	 * stays correct even when the global post is not the resolved page.
 	 */
 	public function has_cart_or_checkout_block(): bool {
-		return has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' );
-	}
 
-	/**
-	 * Whether the current page renders the Mini Cart block.
-	 *
-	 * The Mini Cart is typically inserted via a block-template part (e.g. the
-	 * header) rather than post content, so `has_block()` alone misses it.
-	 * `WC_Blocks_Utils::has_block_in_page()` scans the resolved page including
-	 * template parts; fall back to the post-content check when it is absent.
-	 */
-	public function has_mini_cart(): bool {
-
-		$post_id = get_the_ID();
-
-		if (
-			$post_id
-			&& class_exists( '\WC_Blocks_Utils' )
-			&& \WC_Blocks_Utils::has_block_in_page( (int) $post_id, 'woocommerce/mini-cart' )
-		) {
+		if ( has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ) ) {
 			return true;
 		}
 
-		return has_block( 'woocommerce/mini-cart' );
+		return $this->route_renders_block( 'is_cart', 'cart', 'woocommerce/cart' )
+			|| $this->route_renders_block( 'is_checkout', 'checkout', 'woocommerce/checkout' );
 	}
 
 	/**
-	 * Whether the current page renders any product-filter block.
+	 * Whether the current request is a WooCommerce route whose configured page
+	 * stores the given block in its content.
+	 *
+	 * The route conditional confirms we are on that page; `has_block()` reads
+	 * the configured page's content by ID, which holds the Cart/Checkout block
+	 * on block-built stores and the shortcode on classic stores. Both are
+	 * `function_exists()`-guarded so the helper is safe without WooCommerce.
+	 *
+	 * @param string $conditional The WooCommerce route conditional (e.g. `is_checkout`).
+	 * @param string $page_slug   The WooCommerce page slug (e.g. `checkout`).
+	 * @param string $block_name  The block to look for on that page.
 	 */
-	public function has_filter_block(): bool {
+	private function route_renders_block( string $conditional, string $page_slug, string $block_name ): bool {
 
-		foreach ( $this->get_woocommerce_blocks() as $block_short_name ) {
-			if ( strpos( 'woocommerce/' . $block_short_name, self::FILTER_BLOCK_PREFIX ) === 0 ) {
+		if ( ! $this->wc_route_matches( $conditional ) ) {
+			return false;
+		}
+
+		$page_id = $this->wc_page_id( 'wc_get_page_id', $page_slug );
+
+		return $page_id > 0 && has_block( $block_name, $page_id );
+	}
+
+	/**
+	 * Resolve a WooCommerce page ID by slug, guarded for when WooCommerce is
+	 * not booted.
+	 *
+	 * @param string $resolver  The WooCommerce page-id resolver function name.
+	 * @param string $page_slug The WooCommerce page slug (e.g. `cart`, `checkout`).
+	 */
+	private function wc_page_id( string $resolver, string $page_slug ): int {
+		return function_exists( $resolver ) ? (int) $resolver( $page_slug ) : 0;
+	}
+
+	/**
+	 * Whether the current request is a canonical WooCommerce route.
+	 *
+	 * Theme-independent and reliable for the canonical WC routes, including
+	 * archives (shop, product category/tag) that have no post ID for a
+	 * content scan to read. Each conditional is guarded with
+	 * `function_exists()` so the helper is safe when WooCommerce is not
+	 * booted (the unit tests run without it).
+	 */
+	private function is_woocommerce_route(): bool {
+
+		$conditionals = [
+			'is_cart',
+			'is_checkout',
+			'is_shop',
+			'is_product',
+			'is_product_category',
+			'is_product_tag',
+			'is_product_taxonomy',
+		];
+
+		foreach ( $conditionals as $conditional ) {
+			if ( $this->wc_route_matches( $conditional ) ) {
 				return true;
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * Whether a WooCommerce route conditional is defined and currently true.
+	 *
+	 * Guarded with `function_exists()` so the helper is safe when WooCommerce
+	 * is not booted (the conditionals only exist once WC has loaded).
+	 *
+	 * @param string $conditional The WooCommerce conditional function name.
+	 */
+	private function wc_route_matches( string $conditional ): bool {
+		return function_exists( $conditional ) && (bool) $conditional();
+	}
+
+	/**
+	 * Whether a supported block lives in the site-wide header/footer parts.
+	 *
+	 * Block themes commonly place site-wide WooCommerce blocks (overwhelmingly
+	 * the Mini Cart) in the `header` and `footer` template parts, which the
+	 * post-content scan never sees. Resolved through stable WP core only
+	 * (`wp_is_block_theme()`, `get_stylesheet()`, `get_block_template()`,
+	 * `has_block()`); no dependency on WooCommerce internals. Blocks injected
+	 * via the Block Hooks API are folded in by {@see self::get_template_part_contents()}.
+	 *
+	 * @param array<int, string> $supported The supported block names to match.
+	 */
+	private function has_supported_block_in_template_parts( array $supported ): bool {
+
+		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
+			return false;
+		}
+
+		foreach ( $this->get_template_part_contents() as $content ) {
+			foreach ( $supported as $block_name ) {
+				if ( has_block( $block_name, $content ) ) {
+					return true;
+				}
+			}
+
+			if ( $this->content_has_filter_block( $content ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Resolve the header/footer template-part contents once per request.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_template_part_contents(): array {
+
+		if ( null !== $this->template_part_contents ) {
+			return $this->template_part_contents;
+		}
+
+		$contents = [];
+		$theme    = get_stylesheet();
+
+		foreach ( [ 'header', 'footer' ] as $part_slug ) {
+			$part = get_block_template( $theme . '//' . $part_slug, 'wp_template_part' );
+
+			if ( ! $part || empty( $part->content ) ) {
+				continue;
+			}
+
+			$content = (string) $part->content;
+
+			// Fold in blocks auto-inserted via the Block Hooks API (WP 6.6+),
+			// which a Mini Cart can use to attach to the header without being
+			// stored in the part content.
+			if ( function_exists( 'apply_block_hooks_to_content' ) ) {
+				$content = (string) apply_block_hooks_to_content( $content, $part );
+			}
+
+			$contents[] = $content;
+		}
+
+		$this->template_part_contents = $contents;
+
+		return $contents;
+	}
+
+	/**
+	 * Whether the current post's content renders any product-filter block.
+	 *
+	 * Matches the product-filter family by prefix across the full block tree,
+	 * so filter blocks nested inside Group/Columns/Query wrappers are found,
+	 * not just top-level ones.
+	 */
+	public function has_filter_block(): bool {
+		return $this->content_has_filter_block( $this->get_post_content() );
+	}
+
+	/**
+	 * Whether a content string renders any product-filter block.
+	 *
+	 * @param string $content Serialized block content.
+	 */
+	private function content_has_filter_block( string $content ): bool {
+
+		if ( '' === $content ) {
+			return false;
+		}
+
+		foreach ( $this->flatten_block_names( parse_blocks( $content ) ) as $block_name ) {
+			if ( strpos( $block_name, self::FILTER_BLOCK_PREFIX ) === 0 ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Flatten a parsed block tree to a list of block names.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Parsed blocks.
+	 *
+	 * @return array<int, string>
+	 */
+	private function flatten_block_names( array $blocks ): array {
+
+		$names = [];
+
+		foreach ( $blocks as $block ) {
+			if ( ! empty( $block['blockName'] ) ) {
+				$names[] = (string) $block['blockName'];
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$names = array_merge( $names, $this->flatten_block_names( $block['innerBlocks'] ) );
+			}
+		}
+
+		return $names;
+	}
+
+	/**
+	 * The current post's content, or an empty string when there is no post.
+	 */
+	private function get_post_content(): string {
+
+		$post_id = get_the_ID();
+
+		if ( ! $post_id ) {
+			return '';
+		}
+
+		return (string) get_the_content( null, false, (int) $post_id );
 	}
 
 	/**
@@ -255,11 +476,9 @@ final class WooCommerceBlocks {
 
 		$woocommerce_blocks = [];
 
-		$blocks = parse_blocks( $post_content );
-
-		foreach ( $blocks as $block ) {
-			if ( ! empty( $block['blockName'] ) && strpos( $block['blockName'], 'woocommerce/' ) === 0 ) {
-				$woocommerce_blocks[] = str_replace( 'woocommerce/', '', $block['blockName'] );
+		foreach ( $this->flatten_block_names( parse_blocks( $post_content ) ) as $block_name ) {
+			if ( strpos( $block_name, 'woocommerce/' ) === 0 ) {
+				$woocommerce_blocks[] = str_replace( 'woocommerce/', '', $block_name );
 			}
 		}
 

--- a/tests/phpunit/Unit/Integration/WooCommerceBlocksTest.php
+++ b/tests/phpunit/Unit/Integration/WooCommerceBlocksTest.php
@@ -59,6 +59,42 @@ final class WooCommerceBlocksTest extends TestCase {
 	}
 
 	/**
+	 * Stub every WooCommerce route conditional to false.
+	 *
+	 * Keeps the route safety net deterministic so a test can isolate the
+	 * content or template-part detection layers.
+	 */
+	private function stub_no_wc_route(): void {
+		foreach (
+			[
+				'is_cart',
+				'is_checkout',
+				'is_shop',
+				'is_product',
+				'is_product_category',
+				'is_product_tag',
+				'is_product_taxonomy',
+			] as $conditional
+		) {
+			Functions\when( $conditional )->justReturn( false );
+		}
+	}
+
+	/**
+	 * A `has_block()` alias that honors the optional content-string argument.
+	 *
+	 * With a content string it matches the block name against that string;
+	 * without one it reports no match (no post content under test).
+	 *
+	 * @return callable
+	 */
+	private function content_aware_has_block(): callable {
+		return static function ( string $block_name, $content = null ): bool {
+			return is_string( $content ) && false !== strpos( $content, $block_name );
+		};
+	}
+
+	/**
 	 * Block parsing returns the short names of every WooCommerce block.
 	 *
 	 * @covers \TLA_Media\GTM_Kit\Integration\WooCommerceBlocks::has_woocommerce_blocks
@@ -156,6 +192,8 @@ final class WooCommerceBlocksTest extends TestCase {
 	public function test_has_cart_or_checkout_block(): void {
 		$blocks = $this->make_blocks();
 
+		$this->stub_no_wc_route();
+
 		Functions\when( 'has_block' )->alias(
 			static fn( string $name ): bool => 'woocommerce/checkout' === $name
 		);
@@ -163,6 +201,48 @@ final class WooCommerceBlocksTest extends TestCase {
 		$this->assertTrue( $blocks->has_cart_or_checkout_block() );
 
 		Functions\when( 'has_block' )->justReturn( false );
+		$this->assertFalse( $blocks->has_cart_or_checkout_block() );
+	}
+
+	/**
+	 * On a block-built checkout the Checkout block is stored in the configured
+	 * checkout page's content, so the helper is true even when the global post
+	 * carries no block.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Integration\WooCommerceBlocks::has_cart_or_checkout_block
+	 */
+	public function test_has_cart_or_checkout_block_true_on_block_checkout_page(): void {
+		$blocks = $this->make_blocks();
+
+		Functions\when( 'is_cart' )->justReturn( false );
+		Functions\when( 'is_checkout' )->justReturn( true );
+		Functions\when( 'wc_get_page_id' )->alias(
+			static fn( string $page ): int => 'checkout' === $page ? 42 : 0
+		);
+		Functions\when( 'has_block' )->alias(
+			static fn( string $name, $post = null ): bool => 'woocommerce/checkout' === $name && 42 === $post
+		);
+
+		$this->assertTrue( $blocks->has_cart_or_checkout_block() );
+	}
+
+	/**
+	 * On a classic (shortcode) checkout the configured page stores no Checkout
+	 * block, so the helper is false even though `is_checkout()` is true. This
+	 * keeps the classic checkout/cart tracking scripts loading.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Integration\WooCommerceBlocks::has_cart_or_checkout_block
+	 */
+	public function test_has_cart_or_checkout_block_false_on_classic_checkout(): void {
+		$blocks = $this->make_blocks();
+
+		Functions\when( 'is_cart' )->justReturn( false );
+		Functions\when( 'is_checkout' )->justReturn( true );
+		Functions\when( 'wc_get_page_id' )->alias(
+			static fn( string $page ): int => 'checkout' === $page ? 42 : 0
+		);
+		Functions\when( 'has_block' )->justReturn( false );
+
 		$this->assertFalse( $blocks->has_cart_or_checkout_block() );
 	}
 
@@ -186,7 +266,8 @@ final class WooCommerceBlocksTest extends TestCase {
 	}
 
 	/**
-	 * The page detection method finds the product-filter family by prefix.
+	 * The page detection method finds the product-filter family by prefix,
+	 * including a filter block nested inside a wrapper in post content.
 	 *
 	 * @covers \TLA_Media\GTM_Kit\Integration\WooCommerceBlocks::page_has_supported_blocks
 	 * @covers \TLA_Media\GTM_Kit\Integration\WooCommerceBlocks::has_filter_block
@@ -197,16 +278,131 @@ final class WooCommerceBlocksTest extends TestCase {
 		Filters\expectApplied( 'gtmkit_blocks_supported' )->andReturnFirstArg();
 		Functions\when( 'get_the_ID' )->justReturn( 12 );
 		Functions\when( 'has_block' )->justReturn( false );
-		Functions\when( 'get_the_content' )->justReturn( '' );
+		Functions\when( 'get_the_content' )->justReturn( '<!-- wp:group -->' );
 		Functions\when( 'parse_blocks' )->justReturn(
-			[ [ 'blockName' => 'woocommerce/product-filter-attribute' ] ]
+			[
+				[
+					'blockName'   => 'core/group',
+					'innerBlocks' => [
+						[ 'blockName' => 'woocommerce/product-filter-attribute' ],
+					],
+				],
+			]
 		);
 
 		$this->assertTrue( $blocks->page_has_supported_blocks() );
 	}
 
 	/**
-	 * The page detection method is false when nothing matches.
+	 * The page detection method is true on a canonical WooCommerce route even
+	 * when there is no post ID and no block in content (simulated FSE archive).
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Integration\WooCommerceBlocks::page_has_supported_blocks
+	 */
+	public function test_page_has_supported_blocks_true_via_wc_route(): void {
+		$blocks = $this->make_blocks();
+
+		Filters\expectApplied( 'gtmkit_blocks_supported' )->andReturnFirstArg();
+		Functions\when( 'get_the_ID' )->justReturn( false );
+		Functions\when( 'has_block' )->justReturn( false );
+		Functions\when( 'is_cart' )->justReturn( false );
+		Functions\when( 'is_checkout' )->justReturn( false );
+		Functions\when( 'is_shop' )->justReturn( true );
+
+		$this->assertTrue( $blocks->page_has_supported_blocks() );
+	}
+
+	/**
+	 * The page detection method is true when a supported block lives in a
+	 * header template part on a block theme (FSE Mini Cart in the header).
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Integration\WooCommerceBlocks::page_has_supported_blocks
+	 */
+	public function test_page_has_supported_blocks_true_via_template_part(): void {
+		$blocks = $this->make_blocks();
+
+		Filters\expectApplied( 'gtmkit_blocks_supported' )->andReturnFirstArg();
+		Functions\when( 'get_the_ID' )->justReturn( false );
+		$this->stub_no_wc_route();
+		Functions\when( 'has_block' )->alias( $this->content_aware_has_block() );
+		Functions\when( 'wp_is_block_theme' )->justReturn( true );
+		Functions\when( 'get_stylesheet' )->justReturn( 'twentytwentyfour' );
+		Functions\when( 'get_block_template' )->alias(
+			static function ( string $id ): ?object {
+				if ( 'twentytwentyfour//header' === $id ) {
+					$part          = new \stdClass();
+					$part->content = '<!-- wp:woocommerce/mini-cart /-->';
+					return $part;
+				}
+				return null;
+			}
+		);
+
+		$this->assertTrue( $blocks->page_has_supported_blocks() );
+	}
+
+	/**
+	 * The page detection method is true when a product-filter block lives in a
+	 * footer template part on a block theme.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Integration\WooCommerceBlocks::page_has_supported_blocks
+	 */
+	public function test_page_has_supported_blocks_detects_filter_in_template_part(): void {
+		$blocks = $this->make_blocks();
+
+		Filters\expectApplied( 'gtmkit_blocks_supported' )->andReturnFirstArg();
+		Functions\when( 'get_the_ID' )->justReturn( false );
+		$this->stub_no_wc_route();
+		Functions\when( 'has_block' )->alias( $this->content_aware_has_block() );
+		Functions\when( 'parse_blocks' )->justReturn(
+			[ [ 'blockName' => 'woocommerce/product-filter-price' ] ]
+		);
+		Functions\when( 'wp_is_block_theme' )->justReturn( true );
+		Functions\when( 'get_stylesheet' )->justReturn( 'twentytwentyfour' );
+		Functions\when( 'get_block_template' )->alias(
+			static function ( string $id ): ?object {
+				if ( 'twentytwentyfour//footer' === $id ) {
+					$part          = new \stdClass();
+					$part->content = '<!-- wp:woocommerce/product-filter-price /-->';
+					return $part;
+				}
+				return null;
+			}
+		);
+
+		$this->assertTrue( $blocks->page_has_supported_blocks() );
+	}
+
+	/**
+	 * The page detection method is false on a block theme whose header/footer
+	 * parts resolve but hold no supported block, with no WooCommerce route.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Integration\WooCommerceBlocks::page_has_supported_blocks
+	 */
+	public function test_page_has_supported_blocks_false_on_block_theme_without_block(): void {
+		$blocks = $this->make_blocks();
+
+		Filters\expectApplied( 'gtmkit_blocks_supported' )->andReturnFirstArg();
+		Functions\when( 'get_the_ID' )->justReturn( false );
+		$this->stub_no_wc_route();
+		Functions\when( 'has_block' )->alias( $this->content_aware_has_block() );
+		Functions\when( 'parse_blocks' )->justReturn( [ [ 'blockName' => 'core/paragraph' ] ] );
+		Functions\when( 'wp_is_block_theme' )->justReturn( true );
+		Functions\when( 'get_stylesheet' )->justReturn( 'twentytwentyfour' );
+		Functions\when( 'get_block_template' )->alias(
+			static function (): object {
+				$part          = new \stdClass();
+				$part->content = '<!-- wp:core/paragraph /-->';
+				return $part;
+			}
+		);
+
+		$this->assertFalse( $blocks->page_has_supported_blocks() );
+	}
+
+	/**
+	 * The page detection method is false when nothing matches: not a block
+	 * theme, no blocks in content, and no WooCommerce route.
 	 *
 	 * @covers \TLA_Media\GTM_Kit\Integration\WooCommerceBlocks::page_has_supported_blocks
 	 */
@@ -218,6 +414,8 @@ final class WooCommerceBlocksTest extends TestCase {
 		Functions\when( 'has_block' )->justReturn( false );
 		Functions\when( 'get_the_content' )->justReturn( '' );
 		Functions\when( 'parse_blocks' )->justReturn( [ [ 'blockName' => 'core/paragraph' ] ] );
+		$this->stub_no_wc_route();
+		Functions\when( 'wp_is_block_theme' )->justReturn( false );
 
 		$this->assertFalse( $blocks->page_has_supported_blocks() );
 	}


### PR DESCRIPTION
## Problem

On block (FSE) themes, WooCommerce renders Cart, Checkout, Mini Cart, Product Collection and Related Products from block templates and template parts, not from post content. GTM Kit's block-tracking enqueue was gated on post-content-only detection (`has_block()` / `get_the_content()` + a top-level `parse_blocks()`), so on these shops the gate returned false and `gtmkit-woocommerce-blocks` was never enqueued. The entire block ecommerce tracking path silently did nothing on modern FSE storefronts. The classic-template path was unaffected.

A knock-on bug followed: because `has_cart_or_checkout_block()` was wrongly false on an FSE checkout, the classic `gtmkit-woocommerce-checkout` script loaded there (wrong DOM/data store) while the block bundle was absent, and the classic `gtmkit-woocommerce` script was never dequeued.

## Fix

Detection now happens entirely at `wp_enqueue_scripts` (the bundle is a deferred head script, so the decision must be made before block render) and is layered, cheapest-first with short-circuit:

1. **Post content** — `has_block()` per supported block (also matches blocks nested in Group/Columns/Query wrappers) plus the product-filter family.
2. **WooCommerce route safety net** — `is_cart()`/`is_checkout()`/`is_shop()`/`is_product()`/`is_product_category()`/`is_product_tag()`/`is_product_taxonomy()`, theme-independent and reliable including archives that have no post ID. Each guarded with `function_exists()`.
3. **Header/footer template parts** — block themes only, resolved via stable WP core (`wp_is_block_theme()`, `get_stylesheet()`, `get_block_template()`, `has_block()`); no dependency on WooCommerce internals. This is where the site-wide Mini Cart lives. Resolved part contents are memoized per request and this layer is skipped when an earlier layer already matched.

`has_cart_or_checkout_block()` is now route-aware (`is_cart()`/`is_checkout()`), which fixes both the block-bundle enqueue and the classic-script mis-fire in one move. Filter/nested-block detection flattens the parsed block tree and prefix-matches `woocommerce/product-filter`, checked against both post content and the header/footer parts. The Mini Cart is folded into the unified detection (the previous `has_block_in_page()` special case only read top-level `post_content` and was ineffective on real FSE themes); its inaccurate docblock claim is removed.

The `gtmkit_blocks_supported` filter is honoured by the template-part scan too, so a custom block added via the filter is detected in templates.

## No JavaScript changes

The bundle self-detects at runtime from the DOM (`boot()` mounts subscribers on wrapper-class/store presence; over-enqueue is explicitly harmless), and template-rendered blocks emit the same wrapper classes as content-rendered ones. The `render_block` item-data injection already fired for template-rendered blocks. This is purely a server-side enqueue-detection fix.

Confirmed the `wc.blocks` data feed (`get_global_data()` -> `get_woocommerce_blocks()`, still post-content only) is **not** used as a tracking gate: the block bundle reads the DOM, not `wc.blocks`. The feed is informational, so it is left unchanged.

## Test plan

Verified live on a WooCommerce site (WC 10.8.1) against both a classic theme (Storefront) and a block/FSE theme (Twenty Twenty-Five), with block-built Cart/Checkout pages. Note: with a page cache (WP Rocket) active, detection changes only take effect after a cache purge — the checks below were run with the page cache bypassed.

- [x] Block-built checkout: `gtmkit-woocommerce-blocks` is enqueued, the classic `gtmkit-woocommerce-checkout` is **not**, and the base `gtmkit-woocommerce` is dequeued. ✅ (confirmed on both classic and FSE themes)
- [x] Shop archive (no post ID): bundle enqueued via the WooCommerce route net (also confirmed on product pages). ✅
- [x] FSE theme (Twenty Twenty-Five) with Mini Cart in the header template part: with the Mini Cart present, a plain non-WooCommerce page (home) enqueues the bundle via the Layer 2 template-part scan and the Mini Cart renders; removing the Mini Cart returns the page to no-bundle. ✅ Both positive and negative cases confirmed live.
path, covered by unit tests.
- [x] Page with no WooCommerce blocks and no WooCommerce route (home): bundle is **not** enqueued. ✅
- [x] **Classic (shortcode) checkout regression guard:** with the checkout page temporarily pointed at a `[woocommerce_checkout]` shortcode page, `has_block('woocommerce/checkout', <page id>)` returns false live — the exact input that makes `has_cart_or_checkout_block()` return false, so the classic scripts are preserved. Confirmed by unit test `test_has_cart_or_checkout_block_false_on_classic_checkout`. (Full HTTP render of an empty classic checkout redirects to the cart — a WooCommerce behavior, not this change.) ✅


