### PR TITLE
Release 2.14.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** GTM Kit ***
 
-Unreleased
+2026-06-03 - version 2.14.1
 * Fix: WooCommerce block tracking now loads on block (FSE) themes where Cart, Checkout, Mini Cart, Product Collection, or Related Products are rendered from block templates and template parts. Previously the block tracking bundle could fail to load on these sites, so block ecommerce events never fired.
 
 2026-06-02 - version 2.14.0

--- a/gtm-kit.php
+++ b/gtm-kit.php
@@ -3,7 +3,7 @@
  * GTM Kit Plugin
  *
  * Plugin Name: GTM Kit
- * Version:     2.14.0
+ * Version:     2.14.1
  * Plugin URI:  https://gtmkit.com/
  * Description: Google Tag Manager implementation focusing on flexibility and pagespeed.
  * Author:      GTM Kit
@@ -27,7 +27,7 @@ if ( ! function_exists( 'add_filter' ) ) {
 	exit();
 }
 
-const GTMKIT_VERSION = '2.14.0';
+const GTMKIT_VERSION = '2.14.1';
 
 if ( ! defined( 'GTMKIT_FILE' ) ) {
 	define( 'GTMKIT_FILE', __FILE__ );

--- a/languages/gtm-kit.pot
+++ b/languages/gtm-kit.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv3.
 msgid ""
 msgstr ""
-"Project-Id-Version: GTM Kit 2.14.0\n"
+"Project-Id-Version: GTM Kit 2.14.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/gtm-kit\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-01T09:32:54+00:00\n"
+"POT-Creation-Date: 2026-06-02T15:02:42+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.9.0\n"
 "X-Domain: gtm-kit\n"
@@ -356,7 +356,7 @@ msgstr ""
 msgid "General Product List"
 msgstr ""
 
-#: src/Integration/WooCommerceBlocks.php:340
+#: src/Integration/WooCommerceBlocks.php:559
 msgid "GTM Kit data."
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gtm-kit",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gtm-kit",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "dependencies": {
         "@wordpress/api-fetch": "^7.33.1",
         "@wordpress/components": "^30.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtm-kit",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Development files for the GTM Kit",
   "author": "GTM Kit",
   "keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://github.com/tlamedia/gtm-kit
 Tags: google tag manager, gtm, woocommerce, analytics, ga4
 Requires at least: 6.8
 Tested up to: 7.0
-Stable tag: 2.14.0
+Stable tag: 2.14.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -99,7 +99,11 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= Unreleased =
+= 2.14.1 =
+
+Release date: 2026-06-03
+
+A maintenance fix for the 2.14 line; see the [2.14 release post](https://gtmkit.com/gtm-kit-2-14/) for what 2.14 introduced.
 
 #### Bugfixes:
 * WooCommerce block tracking now loads on block (FSE) themes where Cart, Checkout, Mini Cart, Product Collection, or Related Products are rendered from block templates and template parts. Previously the block tracking bundle could fail to load on these sites, so block ecommerce events never fired.


### PR DESCRIPTION
## Summary

Cuts gtm-kit 2.14.1, a maintenance patch on the 2.14 line.

Headline scope:
- Fix: WooCommerce block tracking now loads on block (FSE) themes where Cart, Checkout, Mini Cart, Product Collection, or Related Products are rendered from block templates and template parts. Previously the block tracking bundle could fail to load on these sites, so block ecommerce events never fired.

Version bump:
- gtm-kit.php — Version header + GTMKIT_VERSION constant
- readme.txt — Stable tag 2.14.1 + canonical `= 2.14.1 =` block, linked to gtmkit.com/gtm-kit-2-14/
- package.json + package-lock.json — 2.14.1

Translation template: languages/gtm-kit.pot regenerated, `Project-Id-Version: GTM Kit 2.14.1`. No new user-facing strings (backend-only fix), so the message diff is version metadata only.

Assets: full build chain re-run (build:assets, blocks, settings, introductions back-fill, consent-gating uglify). No delta versus main — no JS source changed in this patch — so the committed bundles are byte-identical. consent-gating bundle 969/1024 bytes.

"Tested up to" headers already current (WordPress 7.0, WooCommerce 10.8.1); no change.

## Quality gates
- [x] composer phpstan — 0 errors
- [x] composer phpcs — 0 errors, 0 warnings
- [x] PHPUnit unit + integration — 99 + 90 tests pass (1 expected skip)
- [x] Vitest — 100/100 tests pass
- [x] consent-gating bundle size — 969 / 1024 bytes
- [x] Shipped-code review for fatal errors and serious bugs — no fatals or serious bugs; one minor, non-blocking page-weight optimization on classic (non-FSE) themes noted for a future release
