### PR TITLE
Release 2.15.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** GTM Kit ***
 
-Unreleased
+2026-06-12 - version 2.15.0
 * Fix: Security hardening. Links served to the settings interface from remote content (upgrade offers, templates, tutorials) and notifications are now validated before they are used for navigation.
 * Dev: New `gtmkit_settings_registry` filter lets add-ons register their settings fields with the GTM Kit settings screen at runtime. The settings screen now exposes its field registry and related metadata, preparing for GTM Kit's new settings interface.
 

--- a/gtm-kit.php
+++ b/gtm-kit.php
@@ -3,7 +3,7 @@
  * GTM Kit Plugin
  *
  * Plugin Name: GTM Kit
- * Version:     2.14.1
+ * Version:     2.15.0
  * Plugin URI:  https://gtmkit.com/
  * Description: Google Tag Manager implementation focusing on flexibility and pagespeed.
  * Author:      GTM Kit
@@ -27,7 +27,7 @@ if ( ! function_exists( 'add_filter' ) ) {
 	exit();
 }
 
-const GTMKIT_VERSION = '2.14.1';
+const GTMKIT_VERSION = '2.15.0';
 
 if ( ! defined( 'GTMKIT_FILE' ) ) {
 	define( 'GTMKIT_FILE', __FILE__ );

--- a/languages/gtm-kit.pot
+++ b/languages/gtm-kit.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv3.
 msgid ""
 msgstr ""
-"Project-Id-Version: GTM Kit 2.14.1\n"
+"Project-Id-Version: GTM Kit 2.15.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/gtm-kit\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-02T15:02:42+00:00\n"
+"POT-Creation-Date: 2026-06-11T14:23:37+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.9.0\n"
 "X-Domain: gtm-kit\n"
@@ -35,7 +35,7 @@ msgid "Go to GTM Kit Settings page"
 msgstr ""
 
 #: inc/main.php:98
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:29
 msgid "Settings"
 msgstr ""
 
@@ -60,6 +60,10 @@ msgstr ""
 msgid "Go back to the Dashboard"
 msgstr ""
 
+#: src/Admin/AbstractOptionsPage.php:292
+msgid "The plugin is installed and activated"
+msgstr ""
+
 #: src/Admin/AdminAPI.php:134
 #: src/Admin/AdminAPI.php:139
 msgid "The support ticket was not found. Please check that you have entered the correct ticket."
@@ -73,20 +77,20 @@ msgstr ""
 msgid "Invalid input data."
 msgstr ""
 
-#: src/Admin/GeneralOptionsPage.php:100
+#: src/Admin/GeneralOptionsPage.php:110
 #: assets/admin/191.js:1
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:29
 msgid "General"
 msgstr ""
 
-#: src/Admin/GeneralOptionsPage.php:109
+#: src/Admin/GeneralOptionsPage.php:119
 msgid "General Settings"
 msgstr ""
 
 #: src/Admin/HelpOptionsPage.php:61
 #: src/Admin/HelpOptionsPage.php:70
 #: assets/admin/48.js:1
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:29
 msgid "Help"
 msgstr ""
 
@@ -106,7 +110,9 @@ msgstr ""
 #: src/Admin/IntegrationsOptionsPage.php:73
 #: assets/admin/191.js:1
 #: assets/admin/352.js:1
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:25
+#: assets/admin/settings.js:29
 msgid "Integrations"
 msgstr ""
 
@@ -121,6 +127,7 @@ msgstr ""
 #: src/Admin/MetaBox.php:90
 #: assets/admin/563.js:1
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Page type"
 msgstr ""
 
@@ -180,8 +187,9 @@ msgid "Breaking change:"
 msgstr ""
 
 #: src/Admin/Suggestions.php:423
-#: assets/admin/761.js:1
+#: assets/admin/519.js:1
 #: assets/admin/837.js:1
+#: assets/admin/settings.js:10
 msgid "New releases of GTM Kit may contain important updates to comply with changes in Google Tag Manager or analytics in general. We recommend enabling automatic plugin updates for GTM Kit to ensure it is always up to date."
 msgstr ""
 
@@ -229,18 +237,16 @@ msgstr ""
 
 #: src/Admin/TemplatesOptionsPage.php:59
 #: src/Admin/TemplatesOptionsPage.php:68
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
 msgid "GTM Templates"
 msgstr ""
 
 #: src/Admin/UpgradesOptionsPage.php:59
 #: src/Admin/UpgradesOptionsPage.php:68
 #: assets/admin/474.js:1
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:29
 msgid "Upgrades"
-msgstr ""
-
-#: src/Admin/UpgradesOptionsPage.php:133
-msgid "The plugin is installed and activated"
 msgstr ""
 
 #: src/Common/RestAPIServer.php:33
@@ -377,24 +383,20 @@ msgstr ""
 msgid "Tutorials"
 msgstr ""
 
-#: assets/admin/76.js:1
-#: assets/admin/674.js:1
-#: assets/admin/674.js:19
-msgid "(not set)"
-msgstr ""
-
 #. translators: %s is the name of the plugin.
+#. translators: %s: integration name.
 #: assets/admin/76.js:4
 #: assets/admin/345.js:4
-#: assets/admin/674.js:4
+#: assets/admin/567.js:4
 #: assets/admin/838.js:4
+#: assets/admin/settings.js:26
 msgid "%s Integration"
 msgstr ""
 
 #. translators: %s is the name of the plugin.
 #: assets/admin/76.js:7
 #: assets/admin/345.js:7
-#: assets/admin/674.js:7
+#: assets/admin/567.js:7
 #: assets/admin/838.js:7
 msgid "Track %s"
 msgstr ""
@@ -402,163 +404,461 @@ msgstr ""
 #. translators: %s is the name of the plugin.
 #: assets/admin/76.js:10
 #: assets/admin/345.js:10
-#: assets/admin/674.js:10
+#: assets/admin/567.js:10
 #: assets/admin/838.js:10
 msgid "Activate the %s integration"
 msgstr ""
 
-#. translators: %s is the name of the plugin.
-#: assets/admin/76.js:13
-#: assets/admin/345.js:13
-#: assets/admin/674.js:13
-#: assets/admin/838.js:13
-msgid "%s is not active"
-msgstr ""
-
-#. translators: %s is the name of the plugin.
-#: assets/admin/76.js:16
-#: assets/admin/345.js:16
-#: assets/admin/674.js:16
-#: assets/admin/838.js:16
-msgid "If you haven't installed and activated %s you must do that."
-msgstr ""
-
-#. translators: %s is the name of the plugin.
-#: assets/admin/76.js:19
-#: assets/admin/345.js:19
-#: assets/admin/674.js:19
-#: assets/admin/838.js:19
-msgid "Install %s"
-msgstr ""
-
-#: assets/admin/76.js:19
-#: assets/admin/settings.js:1
+#: assets/admin/76.js:10
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
 msgid "Easy Digital Downloads"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/345.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/345.js:10
+#: assets/admin/567.js:10
 msgid "Basic Settings"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Use SKU instead of ID"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Use SKU instead of the product ID with fallback to ID if no SKU is set."
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Exclude tax"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Exclude tax from prices and revenue"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Include customer data"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Enable this option to include customer data in the data layer on the \"purchase\" event."
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
 msgid "Google Ads Settings"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Google Business Vertical"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "In order to use Google Ads Remarketing you must select your business type (vertical)."
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Product ID prefix"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Enter prefix"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "If your product feed generator is adding a prefix to the product IDs, you can add the prefix here to include it in the Data Layer."
 msgstr ""
 
-#: assets/admin/76.js:19
+#: assets/admin/76.js:10
 msgid "Advanced settings"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Dequeue the default JavaScript"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
+#: assets/admin/76.js:10
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Enable this option to dequeue the default JavaScript if you plan to create your own JavaScript."
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
-msgid "Retail"
+#: assets/admin/169.js:1
+#: assets/admin/519.js:1
+#: assets/admin/567.js:1
+msgid "Unlock with premium"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
-msgid "Education"
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:10
+msgid "Event deferral"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
-msgid "Flights"
+#: assets/admin/169.js:1
+msgid "Hold back ecommerce events in the browser until the visitor grants consent, then release them in the order they fired. The decision runs entirely client-side, so a cached page stays identical for every visitor."
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
-msgid "Hotel rental"
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:10
+msgid "Defer events until consent is granted"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
-msgid "Jobs"
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:18
+msgid "Strong-block gating mode holds the whole container back until consent, so per-event deferral stays inert while that mode is active."
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
-msgid "Local deals"
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:18
+msgid "Events to defer"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
-msgid "Real estate"
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:18
+msgid "Checked events wait for consent. Unchecked events fire immediately."
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
-msgid "Travel"
+#: assets/admin/169.js:1
+msgid "Timeout"
 msgstr ""
 
-#: assets/admin/76.js:19
-#: assets/admin/674.js:19
-msgid "Custom"
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:18
+msgid "Seconds to wait"
+msgstr ""
+
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:18
+msgid "How long the queue waits for consent before the timeout fallback runs. 1 to 30 seconds."
+msgstr ""
+
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:18
+msgid "On timeout"
+msgstr ""
+
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:18
+msgid "Flush the queued events anyway"
+msgstr ""
+
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:18
+msgid "Drop the queued events (never fire without consent)"
+msgstr ""
+
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:18
+msgid "Required consent categories"
+msgstr ""
+
+#: assets/admin/169.js:1
+#: assets/admin/settings.js:18
+msgid "Deferred events are released once these consent categories are granted."
+msgstr ""
+
+#. translators: %s is an HTML attribute string rendered in monospace.
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:13
+#: assets/admin/settings.js:15
+#: assets/admin/settings.js:17
+msgid "Adds %s to GTM Kit scripts."
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:29
+msgid "Google Consent Mode"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Script gating"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Choose whether GTM Kit loads the Google Tag Manager container unconditionally, lets it load but hands consent to Consent Mode v2, or holds the container script back until consent is granted."
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Gating mode"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Always load (default)"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Weak block (Consent Mode)"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Strong block"
+msgstr ""
+
+#: assets/admin/169.js:3
+msgid "GTM loads on every page. Use this if your CMP handles consent through Consent Mode tags or attributes, or if you do not yet have a CMP."
+msgstr ""
+
+#: assets/admin/169.js:3
+msgid "GTM loads but starts in denied state via Consent Mode. Tags inside GTM that respect Consent Mode (most do) will not fire until consent is granted. Recommended when using a CMP that publishes consent state to the data layer or to WP Consent API."
+msgstr ""
+
+#: assets/admin/169.js:3
+msgid "GTM does not execute until consent is granted. Strongest privacy posture. Use this if you want a guarantee that no tracking fires before consent. Some tag features that depend on early loading (auto-event listeners, scroll tracking from page-load time) will be limited."
+msgstr ""
+
+#: assets/admin/169.js:3
+msgid "Strong-block mode requires a consent signal to load GTM. With the master toggle off, GTM Kit emits no consent code itself; you must ensure your CMP or custom code fires the gtmkit:consent:updated event when consent is granted, otherwise GTM will not load."
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "CMP script attributes"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "If your consent platform blocks scripts via HTML attributes, enable the matching option below. GTM Kit will add the attribute to its inline scripts so your CMP recognizes them."
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:17
+#: assets/admin/settings.js:18
+msgid "Custom attribute"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:17
+msgid "Use this to add an attribute that is not in the list above. Names accept letters, digits, underscore, and dash; everything else is stripped on save. Leave the name empty to omit the attribute."
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:17
+msgid "Name"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:17
+msgid "Value"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:17
+#: assets/admin/settings.js:18
+msgid "Resulting script tag attributes"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Google Consent Mode Activation"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/389.js:1
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Warning!"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Many consent management platforms (Cookiebot, Complianz, CookieYes, Cookie Information, etc.) handle Google Consent Mode themselves — either via their own client script or via tags inside your GTM container. If your CMP already does this, leave this setting off. Turning it on alongside a CMP that also emits gtag('consent', 'default', …) will cause double-firing and unpredictable consent state."
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Only turn this on if you have no CMP or if your CMP explicitly does not implement Consent Mode itself."
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "GTM Kit will only set the default Consent Mode settings and you must update the settings yourself when the user has given consent. When this setting is on, GTM Kit also exposes window.gtmkit.consent.update() and the gtmkit:consent:updated window event for partner scripts."
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "See an example of how consent is updated"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Activate GCM settings"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Choose this option if you would like to activate the default settings below"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Google Consent Mode Default Settings"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Ad Personalization"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Enables personalized advertising"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Ad Storage"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Enables storage, such as cookies, related to advertising"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Ad User Data"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Enables sending user data related to advertising to Google"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Analytics Storage"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Enables storage, such as cookies, related to analytics (for example, visit duration)"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Functionality Storage"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Enables storage that supports the functionality of the website or app such as language settings"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Personalization Storage"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Enables storage related to personalization such as video recommendations"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Security Storage"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Enables storage related to security such as authentication functionality, fraud prevention, and other user protection"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Advanced"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Redact Ads Data"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Redact advertising data"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Pass through URL parameters"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Pass through ad click, client ID, and session ID information in URLs"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Wait For Update"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Milliseconds to wait for a CMP to call gtag('consent', 'update', …) before tags fire with default state. 500 ms is a safe baseline. Set to 0 to disable the wait."
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Region"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "e.g. DK, DE, US-CA"
+msgstr ""
+
+#: assets/admin/169.js:3
+#: assets/admin/settings.js:10
+msgid "Limit defaults to specific countries or regions (ISO codes, e.g. DK, DE-BY, US-CA). Leave empty to apply globally. Separate multiple codes with commas."
+msgstr ""
+
+#: assets/admin/176.js:1
+msgid "About the assistant"
+msgstr ""
+
+#: assets/admin/176.js:1
+msgid "The assistant builds a ready-to-import GTM container from your setup, with tags, triggers and variables already wired to the data layer GTM Kit pushes. It is a starting point you import into Google Tag Manager, then review and publish yourself."
+msgstr ""
+
+#: assets/admin/176.js:1
+msgid "Read the import guide"
+msgstr ""
+
+#: assets/admin/176.js:1
+msgid "Generating a template never touches your live container. Nothing goes live until you import the file and publish it in Google Tag Manager."
 msgstr ""
 
 #: assets/admin/176.js:1
@@ -574,19 +874,15 @@ msgid "Template Assistant"
 msgstr ""
 
 #: assets/admin/176.js:1
+msgid "Generate a GTM container template from your setup"
+msgstr ""
+
+#: assets/admin/176.js:1
 msgid "Get your Google Tag Manager container template"
 msgstr ""
 
 #: assets/admin/176.js:1
-msgid "GTM Kit is sending data to your Google Tag Manger container but you still need to configure Tags, Triggers and Variables in GTM to use the data."
-msgstr ""
-
-#: assets/admin/176.js:1
-msgid "Below you will find the template generator, which will generate a Google Tag Manager template based on you choices."
-msgstr ""
-
-#: assets/admin/176.js:1
-msgid "When you have generated the template you can import it into your Google Tag Manager container and deploy it."
+msgid "GTM Kit is sending data to your container, but you still need to configure Tags, Triggers and Variables in GTM. The generator builds a template from your choices to import and deploy."
 msgstr ""
 
 #: assets/admin/176.js:1
@@ -662,6 +958,9 @@ msgid "Select the services that you want to send tracking data to."
 msgstr ""
 
 #: assets/admin/176.js:1
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:22
+#: assets/admin/settings.js:25
 msgid "Premium"
 msgstr ""
 
@@ -771,11 +1070,16 @@ msgstr ""
 
 #: assets/admin/191.js:1
 #: assets/admin/352.js:1
+#: assets/admin/settings.js:22
+#: assets/admin/settings.js:25
+#: assets/admin/settings.js:28
+#: assets/admin/settings.js:29
 msgid "Active"
 msgstr ""
 
 #: assets/admin/191.js:1
 #: assets/admin/352.js:1
+#: assets/admin/settings.js:22
 msgid "Inactive"
 msgstr ""
 
@@ -810,7 +1114,7 @@ msgstr ""
 
 #: assets/admin/191.js:1
 #: assets/admin/467.js:4
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:29
 msgid "Notifications"
 msgstr ""
 
@@ -832,8 +1136,10 @@ msgid "See all notifications"
 msgstr ""
 
 #: assets/admin/191.js:1
-#: assets/admin/761.js:1
+#: assets/admin/519.js:1
 #: assets/admin/923.js:1
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:22
 #: assets/admin/wizard.js:1
 msgid "Help improve GTM Kit"
 msgstr ""
@@ -843,345 +1149,87 @@ msgid "Share anonymous data with the development team to help improve GTM Kit."
 msgstr ""
 
 #: assets/admin/191.js:1
-#: assets/admin/761.js:1
+#: assets/admin/519.js:1
 #: assets/admin/923.js:1
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:22
 msgid "Share anonymous data"
 msgstr ""
 
-#: assets/admin/345.js:19
-#: assets/admin/settings.js:1
+#: assets/admin/345.js:10
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
 msgid "Contact Form 7"
 msgstr ""
 
-#: assets/admin/345.js:19
+#: assets/admin/345.js:10
+#: assets/admin/settings.js:10
 msgid "Load JavaScript"
 msgstr ""
 
-#: assets/admin/345.js:19
+#: assets/admin/345.js:10
+#: assets/admin/settings.js:10
 msgid "Only on pages where the Contact Form 7 script is registered (recommended)."
 msgstr ""
 
-#: assets/admin/345.js:19
+#: assets/admin/345.js:10
+#: assets/admin/settings.js:10
 msgid "On all pages"
 msgstr ""
 
-#: assets/admin/345.js:19
+#: assets/admin/345.js:10
+#: assets/admin/settings.js:10
 msgid "Where do you want load the JavaScript?"
 msgstr ""
 
-#: assets/admin/368.js:1
-#: assets/admin/674.js:1
-#: assets/admin/761.js:1
-msgid "Unlock with premium"
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Event deferral"
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Hold back ecommerce events in the browser until the visitor grants consent, then release them in the order they fired. The decision runs entirely client-side, so a cached page stays identical for every visitor."
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Defer events until consent is granted"
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Strong-block gating mode holds the whole container back until consent, so per-event deferral stays inert while that mode is active."
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Events to defer"
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Checked events wait for consent. Unchecked events fire immediately."
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Timeout"
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Seconds to wait"
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "How long the queue waits for consent before the timeout fallback runs. 1 to 30 seconds."
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "On timeout"
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Flush the queued events anyway"
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Drop the queued events (never fire without consent)"
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Required consent categories"
-msgstr ""
-
-#: assets/admin/368.js:1
-msgid "Deferred events are released once these consent categories are granted."
-msgstr ""
-
-#. translators: %s is an HTML attribute string rendered in monospace.
-#: assets/admin/368.js:3
-msgid "Adds %s to GTM Kit scripts."
-msgstr ""
-
-#: assets/admin/368.js:3
-#: assets/admin/settings.js:1
-msgid "Google Consent Mode"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Script gating"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Choose whether GTM Kit loads the Google Tag Manager container unconditionally, lets it load but hands consent to Consent Mode v2, or holds the container script back until consent is granted."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Gating mode"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Always load (default)"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Weak block (Consent Mode)"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Strong block"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "GTM loads on every page. Use this if your CMP handles consent through Consent Mode tags or attributes, or if you do not yet have a CMP."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "GTM loads but starts in denied state via Consent Mode. Tags inside GTM that respect Consent Mode (most do) will not fire until consent is granted. Recommended when using a CMP that publishes consent state to the data layer or to WP Consent API."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "GTM does not execute until consent is granted. Strongest privacy posture. Use this if you want a guarantee that no tracking fires before consent. Some tag features that depend on early loading (auto-event listeners, scroll tracking from page-load time) will be limited."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Strong-block mode requires a consent signal to load GTM. With the master toggle off, GTM Kit emits no consent code itself; you must ensure your CMP or custom code fires the gtmkit:consent:updated event when consent is granted, otherwise GTM will not load."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "CMP script attributes"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "If your consent platform blocks scripts via HTML attributes, enable the matching option below. GTM Kit will add the attribute to its inline scripts so your CMP recognizes them."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Custom attribute"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Use this to add an attribute that is not in the list above. Names accept letters, digits, underscore, and dash; everything else is stripped on save. Leave the name empty to omit the attribute."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Name"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Value"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Resulting script tag attributes"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Google Consent Mode Activation"
-msgstr ""
-
-#: assets/admin/368.js:3
 #: assets/admin/389.js:1
-#: assets/admin/523.js:1
-msgid "Warning!"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Many consent management platforms (Cookiebot, Complianz, CookieYes, Cookie Information, etc.) handle Google Consent Mode themselves — either via their own client script or via tags inside your GTM container. If your CMP already does this, leave this setting off. Turning it on alongside a CMP that also emits gtag('consent', 'default', ...) will cause double-firing and unpredictable consent state."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Only turn this on if you have no CMP or if your CMP explicitly does not implement Consent Mode itself."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "GTM Kit will only set the default Consent Mode settings and you must update the settings yourself when the user has given consent. When this setting is on, GTM Kit also exposes window.gtmkit.consent.update() and the gtmkit:consent:updated window event for partner scripts."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "See an example of how consent is updated"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Activate GCM settings"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Choose this option if you would like to activate the default settings below"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Google Consent Mode Default Settings"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Ad Personalization"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Enables personalized advertising"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Ad Storage"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Enables storage, such as cookies, related to advertising"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Ad User Data"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Enables sending user data related to advertising to Google"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Analytics Storage"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Enables storage, such as cookies, related to analytics (for example, visit duration)"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Functionality Storage"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Enables storage that supports the functionality of the website or app such as language settings"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Personalization Storage"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Enables storage related to personalization such as video recommendations"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Security Storage"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Enables storage related to security such as authentication functionality, fraud prevention, and other user protection"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Advanced"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Redact Ads Data"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Redact advertising data"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Pass through URL parameters"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Pass through ad click, client ID, and session ID information in URLs"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Wait For Update"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Milliseconds to wait for a CMP to call gtag('consent', 'update', ...) before tags fire with default state. 500 ms is a safe baseline. Set to 0 to disable the wait."
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Region"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "e.g. DK, DE, US-CA"
-msgstr ""
-
-#: assets/admin/368.js:3
-msgid "Limit defaults to specific countries or regions (ISO codes, e.g. DK, DE-BY, US-CA). Leave empty to apply globally. Separate multiple codes with commas."
-msgstr ""
-
-#: assets/admin/389.js:1
-#: assets/admin/674.js:19
-#: assets/admin/settings.js:1
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:29
 msgid "User Data"
 msgstr ""
 
 #: assets/admin/389.js:1
+#: assets/admin/settings.js:10
 msgid "Including user data is not compatible with full page caching."
 msgstr ""
 
 #: assets/admin/389.js:1
+#: assets/admin/settings.js:10
 msgid "Full page caching will cache user data making it the same for all users. There are ways around this, but it depends on the chosen cache solution and is only for advanced users."
 msgstr ""
 
 #: assets/admin/389.js:1
+#: assets/admin/settings.js:10
 msgid "User Data Settings"
 msgstr ""
 
 #: assets/admin/389.js:1
+#: assets/admin/settings.js:10
 msgid "Logged in"
 msgstr ""
 
 #: assets/admin/389.js:1
+#: assets/admin/settings.js:10
 msgid "Include whether the user is logged in."
 msgstr ""
 
 #: assets/admin/389.js:1
+#: assets/admin/settings.js:10
 msgid "User ID"
 msgstr ""
 
 #: assets/admin/389.js:1
+#: assets/admin/settings.js:10
 msgid "Include the user ID if the user is logged in."
 msgstr ""
 
 #: assets/admin/389.js:1
+#: assets/admin/settings.js:10
 msgid "User role"
 msgstr ""
 
 #: assets/admin/389.js:1
+#: assets/admin/settings.js:10
 msgid "Include the user role if the user is logged in."
 msgstr ""
 
@@ -1210,6 +1258,7 @@ msgid "Plugin Homepage"
 msgstr ""
 
 #: assets/admin/428.js:1
+#: assets/admin/settings.js:29
 msgid "Share system data with the GTM Kit support team"
 msgstr ""
 
@@ -1222,14 +1271,17 @@ msgid "Enter support ticket"
 msgstr ""
 
 #: assets/admin/428.js:1
+#: assets/admin/settings.js:29
 msgid "Send system data"
 msgstr ""
 
 #: assets/admin/467.js:1
+#: assets/admin/settings.js:22
 msgid "Restore"
 msgstr ""
 
 #: assets/admin/467.js:1
+#: assets/admin/settings.js:22
 msgid "Dismiss"
 msgstr ""
 
@@ -1241,8 +1293,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: assets/admin/467.js:4
-#: assets/admin/761.js:1
-#: assets/admin/settings.js:1
+#: assets/admin/519.js:1
+#: assets/admin/settings.js:29
 msgid "Misc"
 msgstr ""
 
@@ -1270,368 +1322,98 @@ msgstr ""
 msgid "Learn More"
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "No patterns configured. GTM Kit loads on every frontend page."
+#: assets/admin/519.js:1
+#: assets/admin/837.js:1
+#: assets/admin/settings.js:10
+#: assets/admin/wizard.js:1
+msgid "Automatic Updates"
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Pattern"
+#: assets/admin/519.js:1
+#: assets/admin/837.js:1
+#: assets/admin/settings.js:10
+msgid "You can, of course, manually update GTM Kit whenever it suits you, but we highly recommend that you regularly update your plugins and themes to the latest versions to keep your site secure."
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Mode"
+#: assets/admin/519.js:1
+#: assets/admin/837.js:1
+#: assets/admin/settings.js:10
+msgid "Enable Automatic Updates"
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Invalid regular expression."
+#: assets/admin/519.js:1
+#: assets/admin/837.js:1
+#: assets/admin/settings.js:10
+msgid "Automatically update the GTM Kit plugin when new releases are available."
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Invalid regular expression:"
+#: assets/admin/519.js:1
+#: assets/admin/settings.js:10
+msgid "Logging and debugging"
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Glob"
+#: assets/admin/519.js:1
+#: assets/admin/settings.js:10
+msgid "Event Inspector"
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Regex"
+#: assets/admin/519.js:1
+msgid "The event inspector is placed in the footer of the frontand and allows you to see all the fired GTM events."
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Remove pattern"
+#: assets/admin/519.js:1
+msgid "The Event Inspector loads only for logged-in administrators or when WP_DEBUG is enabled. It is disabled entirely under strong-block consent mode."
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Remove"
+#: assets/admin/519.js:1
+#: assets/admin/settings.js:10
+msgid "Console log"
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Add pattern"
+#: assets/admin/519.js:1
+#: assets/admin/settings.js:10
+msgid "Log helpful messages and warnings to the browser log."
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Maximum of 100 patterns reached."
+#: assets/admin/519.js:1
+#: assets/admin/settings.js:10
+msgid "Debug log"
 msgstr ""
 
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "Help finding GTM Container ID"
+#: assets/admin/519.js:1
+#: assets/admin/settings.js:10
+msgid "Log the \"purchase\" event to the debug log."
 msgstr ""
 
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "Where to find your GTM Container ID"
+#: assets/admin/519.js:1
+#: assets/admin/settings.js:10
+msgid "GTM Kit will never transmit any domain names or container ID's."
 msgstr ""
 
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "You can find your GTM Container ID in Google Tag Manager at the top of your workspace. It looks like GTM-XXXXXXX."
+#: assets/admin/519.js:1
+#: assets/admin/923.js:1
+#: assets/admin/settings.js:10
+msgid "I agree to share anonymous data with the development team to help improve GTM Kit."
 msgstr ""
 
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "GTM Container ID location in Google Tag Manager"
+#: assets/admin/519.js:1
+msgid "About GTM Kit"
 msgstr ""
 
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "Open Google Tag Manager"
+#: assets/admin/519.js:1
+msgid "Version:"
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "Google Tag Manager container"
+#: assets/admin/519.js:1
+msgid "Learn about changes and follow the development of GTM Kit:"
 msgstr ""
 
-#: assets/admin/523.js:1
-msgid "General Container Settings"
+#: assets/admin/519.js:1
+msgid "The changelog"
 msgstr ""
 
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "To start collecting data with Google Tag manager you must register the Container ID of your Google Tag Manager container."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "GTM Container ID:"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Enter GTM Container ID"
-msgstr ""
-
-#: assets/admin/523.js:1
-#: assets/admin/767.js:1
-msgid "Find your Container ID in Google Tag Manager"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Inject Container Code"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Setting this to Off will remove the Google Tag Manager container code but the data layer will remain."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Just the container"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Setting this to On will reduce the functionality to just the GTM container code. No additional data will be pushed to the datalayer regardless of any other settings."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "dataLayer variable name:"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "The default name of the data layer object is dataLayer. If you prefer to use a different name for your data layer, you may do so."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Exclude pages from GTM"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Add URL patterns to suppress GTM Kit on matching pages. The container, noscript iframe, and dataLayer scripts all stay off when the current request path matches one of the patterns below."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Matching is on the URL path only: query string is ignored, casing is ignored, and a single trailing slash is normalised. Empty list = GTM Kit loads on every page. On subdirectory installs, patterns must include the full path (e.g. /shop/checkout-embed/*)."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Examples"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "— third-party checkout iframe routes"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "— partner-hosted subpages with their own analytics"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "— in-app webview routes"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Pattern syntax"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Glob mode (default): * matches any run of characters including /; ? matches a single character; all other characters are matched literally."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Regex mode: enter a raw PCRE pattern without delimiters. The matcher adds ~ delimiters and the i flag. Invalid patterns are rejected on save."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Server-side Tagging (sGTM)"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "sGTM Container Domain:"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Enter domain"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Enter your custom domain name if you are using a custom server side GTM container for tracking."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "sGTM container identifier:"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Enter loader name"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Only use if you are using a custom loader."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Cookie Keeper (for Stape users only)"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Prolong cookie lifetime in Safari and other browsers with ITP. This only works if you use Stape sGTM hosting and have set up the Cookie Keeper power up."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Google Tag Manager Server-side Tagging"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Server-side tagging is a silver bullet that gives you improved data accuracy, performance, privacy, and flexibility."
-msgstr ""
-
-#: assets/admin/523.js:1
-#: assets/admin/674.js:19
-msgid "Learn more"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Hosting server-side GTM containers"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Setting up server-side tracking can be challenging and costly but there is an easy and cheap solution."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Stape.io is a solution for hosting server-side Google Tag Manager containers, offering a simplified approach that demands less technical expertise than solutions like Google Cloud Platform."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Additionally, it provides valuable add-ons for enhanced functionality."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Learn more about Stape.io"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Page Speed Optimization"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "load_delayed_js event"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Setting this to On will push the event 'load_delayed_js' on page load."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Delay JavaScript execution"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Page optimization plugins can delay the 'load_delayed_js' event and this can be used to delay the triggering og tags in Google Tag Manager."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Google Tag Manager Environment"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "gtm_auth:"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Enter gtm_auth code"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Enter the gtm_auth code for your GTM environment."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "gtm_preview:"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Enter gtm_preview code"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Enter the gtm_preview code for your GTM environment."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Environments"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "In Google Tag Manager you can define different environments like Live, Dev and QA."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "To use a specific environment in GTM Kit you must enter the \"gtm_auth\" and \"gtm_preview\" codes for that environment."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "If left empty the default environment will be used."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Override settings in wp-config.php"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "You can override the values by using constants in wp-config.php, which is a very useful for setting the value in your development and staging environments."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Exclude User Roles"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Exclude user roles"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Select the roles that you want to exclude from tracking."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Excluding user roles is not compatible with all full-page cache solutions. Some full-page cache solutions may cache the page identically for all users, regardless of their user role. This could result in users being excluded who should not be."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Please ensure thorough and proper testing of this."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Container Code Implementation"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Container code implementation:"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Standard implementation as recommended by Google (no delay)"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Load container when the browser is idle (requestIdleCallback)"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Depending on how you use Google Tag Manager you can delay the loading of the container script until the browser is idle."
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Container code noscript implementation:"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Just after the opening <body> tag"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Footer of the page (not recommended by Google)"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Custom (insert function in your template)"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "Disable <noscript> implementation"
-msgstr ""
-
-#: assets/admin/523.js:1
-msgid "The preferred method to implement the <noscript> container code is just after the opening <body> tag. This requires that your theme uses the \"body_open\" hook. If your theme does not support this the script can be injected in the footer or you can use the function below."
+#: assets/admin/519.js:1
+msgid "The GitHub repository"
 msgstr ""
 
 #: assets/admin/563.js:1
@@ -1648,6 +1430,7 @@ msgid "Include the page type i.e. page, product, category, cart, checkout etc in
 msgstr ""
 
 #: assets/admin/563.js:1
+#: assets/admin/settings.js:10
 msgid "Track WooCommerce"
 msgstr ""
 
@@ -1656,6 +1439,7 @@ msgid "Would you like to track e-commerce data from WooCommerce?"
 msgstr ""
 
 #: assets/admin/563.js:1
+#: assets/admin/settings.js:10
 msgid "Track Contact Form 7"
 msgstr ""
 
@@ -1664,6 +1448,7 @@ msgid "Would you like to track form submissions from Contact Form 7?"
 msgstr ""
 
 #: assets/admin/563.js:1
+#: assets/admin/settings.js:10
 msgid "Track Easy Digital Downloads"
 msgstr ""
 
@@ -1678,350 +1463,727 @@ msgstr ""
 msgid "Save and continue"
 msgstr ""
 
-#: assets/admin/674.js:19
-#: assets/admin/settings.js:1
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
 msgid "WooCommerce"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Brand"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Select the taxonomy that is used for product brands"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Exclude shipping from revenue"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "User-Provided Data"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "The user data is available in the datalayer in 'ecommerce.customer' and a subset of the user data formatted for the 'User-Provided Data' variable is available in 'user-data'."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Learn more"
+msgstr ""
+
+#: assets/admin/567.js:10
 msgid "Webhooks for Server-side Tracking"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "In order to use webhooks you must first enable Server-side Tagging by entering a sGTM Container Domain"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Go to sGTM settings"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "In order to use webhooks you must configure you server-side container to handle the webhooks"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 #: assets/admin/809.js:1
 msgid "Go to GTM Templates"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Send webhooks to server GTM container"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "This option will allow you to send GTM events using webhooks to your server GTM container."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Send webhooks from a background queue"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Dispatch webhooks from a background queue instead of during the checkout request, so the checkout is not held up by the server container. Failed deliveries are retried automatically."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Queued jobs appear under"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Scheduled Actions"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "GTM Events Send by Server-Side Webhooks:"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Send an 'purchase' event from the server side when an order is created."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Send 'purchase' event when an order is created.'"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Send 'purchase' event when the order has been paid and order status is 'Processing'."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Send an 'order_paid' event from the server side when an order has 'Processing' status."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Send an 'refund' event from the server side when an order has been refunded or cancelled."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+msgid "Order Status Events:"
+msgstr ""
+
+#: assets/admin/567.js:10
+msgid "Order status events are always delivered via the background queue, so they are sent reliably even when the status changes without a customer browser present (admin, cron, or payment gateway)."
+msgstr ""
+
+#: assets/admin/567.js:10
+msgid "Send an 'order_processing' event from the server side when an order transitions to the 'Processing' status. Fires alongside 'order_paid' when both are enabled."
+msgstr ""
+
+#: assets/admin/567.js:10
+msgid "Send an 'order_completed' event from the server side when an order transitions to the 'Completed' status."
+msgstr ""
+
+#: assets/admin/567.js:10
+msgid "Send an 'order_refunded' event from the server side when an order's status changes to 'Refunded'. This is the full-refund status event; individual refunds are covered by the 'refund' event."
+msgstr ""
+
+#: assets/admin/567.js:10
 msgid "WooCommerce Subscriptions Events:"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Send a 'subscription_started' event from the server side when a subscription is created."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Send a 'subscription_renewed' event from the server side when a renewal payment completes (including off-session cron renewals)."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Send a 'subscription_cancelled' event from the server side when a subscription is cancelled."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Send a 'subscription_expired' event from the server side when a subscription expires."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Send a 'subscription_reactivated' event from the server side when a cancelled or expired subscription is reactivated."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+msgid "Server-Side Consent:"
+msgstr ""
+
+#: assets/admin/567.js:10
+msgid "Apply the consent given at checkout to the identifiers sent in server-side webhooks. The consent state is recorded when the order is placed and governs every later webhook for that order, including subscription renewals."
+msgstr ""
+
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
+msgid "Consent gating of webhooks"
+msgstr ""
+
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
+msgid "Off: send webhooks regardless of the consent given at checkout."
+msgstr ""
+
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
+msgid "Suppress: strip identifiers the customer did not consent to, and do not send the webhook at all when both marketing and analytics consent were denied."
+msgstr ""
+
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
+msgid "Anonymize: strip identifiers the customer did not consent to, but always send the webhook so aggregate conversion data is preserved."
+msgstr ""
+
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
+msgid "Unknown consent"
+msgstr ""
+
+#: assets/admin/567.js:10
+msgid "How to handle orders with no recorded consent state, for example orders placed before consent capture or created by an administrator."
+msgstr ""
+
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
+msgid "Treat unknown consent as granted and send the webhook unchanged."
+msgstr ""
+
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
+msgid "Treat unknown consent as denied."
+msgstr ""
+
+#: assets/admin/567.js:10
 msgid "Event Customization"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Push view_item_list when the list is updated using a product filter."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Only only push view_item_list once per per page for each list."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Do you what to push the view_item_list event if the list is updated using a filter or just once per page view?"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Only push view_item on the master product"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Push view_item on master and variation products (higher number of views)."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Only push view_item on variation products."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "When do you want to fire the \"view_item\" event on variable products?"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "When the 'Place order' button is clicked"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "When a shipment method is selected with fallback to the 'Place order' button."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Disable the 'add_shipment_info' event."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "When do you want to fire the \"add_shipment_info\" event?"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "When a payment method is selected with fallback to the 'Place order' button."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Disable the 'add_payment_info' event."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "When do you want to fire the \"add_payment_info\" event?"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Disable the 'purchase' event in frontend an rely on server-side webhook."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Disable the 'subscription_started' event in frontend and rely on the server-side webhook."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Custom CSS Selectors"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "If your shop is not compatible with the default CSS selectors you can specify your own CSS selectors."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Single Product (add_to_wishlist):"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Enter CSS selector"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Enter the CSS selector that matches button, which should be use to fire the add_to_wishlist event."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Product List (select_item):"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Enter the CSS selector that matches your product list item, which should be use to fire the select_item event."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Product List (add_to_wishlist):"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Advanced Settings"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Custom Order Received Page"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Enable custom order received (thank you) page"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Select Page"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Select a custom page to use as the order received (thank you) page"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Include permalink structure"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Enable this option to include the permalink structure of the product base, category base, tag base and attribute base."
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
 msgid "Include path of pages"
 msgstr ""
 
-#: assets/admin/674.js:19
+#: assets/admin/567.js:10
+#: assets/admin/settings.js:10
 msgid "Enable this option to include the path of cart, checkout, order received and my account page."
 msgstr ""
 
-#: assets/admin/761.js:1
-#: assets/admin/923.js:1
-msgid "GTM Kit is used together with a wide variety of server configurations and plugins. It is very helpful for us to know what some of these configurations are so we can test the most common configurations."
+#: assets/admin/756.js:1
+msgid "Google Tag Manager container"
 msgstr ""
 
-#: assets/admin/761.js:1
-#: assets/admin/923.js:1
-msgid "You can help by sharing anonymous data with us. Below is a detailed view of all data GTM Kit will collect if granted permission:"
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "General Container Settings"
 msgstr ""
 
-#: assets/admin/761.js:1
-#: assets/admin/837.js:1
-#: assets/admin/wizard.js:1
-msgid "Automatic Updates"
+#: assets/admin/756.js:1
+#: assets/admin/767.js:1
+#: assets/admin/settings.js:10
+msgid "To start collecting data with Google Tag manager you must register the Container ID of your Google Tag Manager container."
 msgstr ""
 
-#: assets/admin/761.js:1
-#: assets/admin/837.js:1
-msgid "You can, of course, manually update GTM Kit whenever it suits you, but we highly recommend that you regularly update your plugins and themes to the latest versions to keep your site secure."
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "GTM Container ID:"
 msgstr ""
 
-#: assets/admin/761.js:1
-#: assets/admin/837.js:1
-msgid "Enable Automatic Updates"
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Enter GTM Container ID"
 msgstr ""
 
-#: assets/admin/761.js:1
-#: assets/admin/837.js:1
-msgid "Automatically update the GTM Kit plugin when new releases are available."
+#: assets/admin/756.js:1
+#: assets/admin/767.js:1
+#: assets/admin/settings.js:17
+msgid "Find your Container ID in Google Tag Manager"
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "Logging and debugging"
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Inject Container Code"
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "Event Inspector"
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Setting this to Off will remove the Google Tag Manager container code but the data layer will remain."
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "The event inspector is placed in the footer of the frontand and allows you to see all the fired GTM events."
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Just the container"
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "The Event Inspector loads only for logged-in administrators or when WP_DEBUG is enabled. It is disabled entirely under strong-block consent mode."
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Setting this to On will reduce the functionality to just the GTM container code. No additional data will be pushed to the datalayer regardless of any other settings."
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "Console log"
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "dataLayer variable name:"
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "Log helpful messages and warnings to the browser log."
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "The default name of the data layer object is dataLayer. If you prefer to use a different name for your data layer, you may do so."
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "Debug log"
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Exclude pages from GTM"
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "Log the \"purchase\" event to the debug log."
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Add URL patterns to suppress GTM Kit on matching pages. The container, noscript iframe, and dataLayer scripts all stay off when the current request path matches one of the patterns below."
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "GTM Kit will never transmit any domain names or container ID's."
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Matching is on the URL path only: query string is ignored, casing is ignored, and a single trailing slash is normalised. Empty list = GTM Kit loads on every page. On subdirectory installs, patterns must include the full path (e.g. /shop/checkout-embed/*)."
 msgstr ""
 
-#: assets/admin/761.js:1
-#: assets/admin/923.js:1
-msgid "I agree to share anonymous data with the development team to help improve GTM Kit."
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Examples"
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "About GTM Kit"
+#: assets/admin/756.js:1
+msgid "— third-party checkout iframe routes"
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "Version:"
+#: assets/admin/756.js:1
+msgid "— partner-hosted subpages with their own analytics"
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "Learn about changes and follow the development of GTM Kit:"
+#: assets/admin/756.js:1
+msgid "— in-app webview routes"
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "The changelog"
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Pattern syntax"
 msgstr ""
 
-#: assets/admin/761.js:1
-msgid "The GitHub repository"
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Glob mode (default): * matches any run of characters including /; ? matches a single character; all other characters are matched literally."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Regex mode: enter a raw PCRE pattern without delimiters. The matcher adds ~ delimiters and the i flag. Invalid patterns are rejected on save."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Server-side Tagging (sGTM)"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "sGTM Container Domain:"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Enter domain"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Enter your custom domain name if you are using a custom server side GTM container for tracking."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "sGTM container identifier:"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Enter loader name"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Only use if you are using a custom loader."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Cookie Keeper (for Stape users only)"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Prolong cookie lifetime in Safari and other browsers with ITP. This only works if you use Stape sGTM hosting and have set up the Cookie Keeper power up."
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "Google Tag Manager Server-side Tagging"
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "Server-side tagging is a silver bullet that gives you improved data accuracy, performance, privacy, and flexibility."
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "Hosting server-side GTM containers"
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "Setting up server-side tracking can be challenging and costly but there is an easy and cheap solution."
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "Stape.io is a solution for hosting server-side Google Tag Manager containers, offering a simplified approach that demands less technical expertise than solutions like Google Cloud Platform."
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "Additionally, it provides valuable add-ons for enhanced functionality."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Learn more about Stape.io"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Page Speed Optimization"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "load_delayed_js event"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Setting this to On will push the event 'load_delayed_js' on page load."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Delay JavaScript execution"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Page optimization plugins can delay the 'load_delayed_js' event and this can be used to delay the triggering og tags in Google Tag Manager."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Google Tag Manager Environment"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "gtm_auth:"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Enter gtm_auth code"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Enter the gtm_auth code for your GTM environment."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "gtm_preview:"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Enter gtm_preview code"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Enter the gtm_preview code for your GTM environment."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Environments"
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "In Google Tag Manager you can define different environments like Live, Dev and QA."
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "To use a specific environment in GTM Kit you must enter the \"gtm_auth\" and \"gtm_preview\" codes for that environment."
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "If left empty the default environment will be used."
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "Override settings in wp-config.php"
+msgstr ""
+
+#: assets/admin/756.js:1
+msgid "You can override the values by using constants in wp-config.php, which is a very useful for setting the value in your development and staging environments."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Exclude User Roles"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Exclude user roles"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Select the roles that you want to exclude from tracking."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Excluding user roles is not compatible with all full-page cache solutions. Some full-page cache solutions may cache the page identically for all users, regardless of their user role. This could result in users being excluded who should not be."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Please ensure thorough and proper testing of this."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Container Code Implementation"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Container code implementation:"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Standard implementation as recommended by Google (no delay)"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Load container when the browser is idle (requestIdleCallback)"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Depending on how you use Google Tag Manager you can delay the loading of the container script until the browser is idle."
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Container code noscript implementation:"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Just after the opening <body> tag"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Footer of the page (not recommended by Google)"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Custom (insert function in your template)"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "Disable <noscript> implementation"
+msgstr ""
+
+#: assets/admin/756.js:1
+#: assets/admin/settings.js:10
+msgid "The preferred method to implement the <noscript> container code is just after the opening <body> tag. This requires that your theme uses the \"body_open\" hook. If your theme does not support this the script can be injected in the footer or you can use the function below."
+msgstr ""
+
+#: assets/admin/767.js:1
+#: assets/admin/settings.js:1
+msgid "Help finding GTM Container ID"
+msgstr ""
+
+#: assets/admin/767.js:1
+#: assets/admin/settings.js:1
+msgid "Where to find your GTM Container ID"
+msgstr ""
+
+#: assets/admin/767.js:1
+#: assets/admin/settings.js:1
+msgid "You can find your GTM Container ID in Google Tag Manager at the top of your workspace. It looks like GTM-XXXXXXX."
+msgstr ""
+
+#: assets/admin/767.js:1
+#: assets/admin/settings.js:1
+msgid "GTM Container ID location in Google Tag Manager"
+msgstr ""
+
+#: assets/admin/767.js:1
+#: assets/admin/settings.js:1
+msgid "Open Google Tag Manager"
 msgstr ""
 
 #: assets/admin/767.js:1
@@ -2093,118 +2255,154 @@ msgstr ""
 msgid "Go to the dashboard"
 msgstr ""
 
+#: assets/admin/923.js:1
+#: assets/admin/settings.js:10
+msgid "GTM Kit is used together with a wide variety of server configurations and plugins. It is very helpful for us to know what some of these configurations are so we can test the most common configurations."
+msgstr ""
+
+#: assets/admin/923.js:1
+#: assets/admin/settings.js:10
+msgid "You can help by sharing anonymous data with us. Below is a detailed view of all data GTM Kit will collect if granted permission:"
+msgstr ""
+
 #: assets/admin/958.js:1
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:29
 msgid "Post Data"
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Post Data Settings"
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Specify which post data elements you wish to include in the dataLayer for use in Google Tag Manager."
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Post type"
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Include the type of the current post or archive page."
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Include the defined page type. I.e. post, page, product, category, cart, checkout etc. You may override this on page-level and set you own page type i.e. \"campaign\"."
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Categories"
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Include the categories of the current post or archive page."
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Tags"
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Include the tags of the current post or archive page."
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Post title"
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Include the Post ID of the current post."
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Post ID"
 msgstr ""
 
 #: assets/admin/958.js:1
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
 msgid "Post data"
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Include the post date."
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Post author name"
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Include the post author name."
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Post author ID"
 msgstr ""
 
 #: assets/admin/958.js:1
+#: assets/admin/settings.js:10
 msgid "Include the post author ID."
 msgstr ""
 
 #: assets/admin/996.js:1
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:29
 msgid "Engagement events"
 msgstr ""
 
 #: assets/admin/996.js:1
+#: assets/admin/settings.js:10
 msgid "GA4 standard events"
 msgstr ""
 
 #: assets/admin/996.js:1
+#: assets/admin/settings.js:10
 msgid "Fire GA4 standard engagement events for logins, sign-ups, on-site search, and Contact Form 7 lead submissions. Each event can be disabled independently if your GTM container or GA4 setup already covers it."
 msgstr ""
 
 #: assets/admin/996.js:1
+#: assets/admin/settings.js:10
 msgid "Login"
 msgstr ""
 
 #: assets/admin/996.js:1
+#: assets/admin/settings.js:10
 msgid "Fires `login` on successful WordPress and WooCommerce account logins."
 msgstr ""
 
 #: assets/admin/996.js:1
+#: assets/admin/settings.js:10
 msgid "Sign-up"
 msgstr ""
 
 #: assets/admin/996.js:1
+#: assets/admin/settings.js:10
 msgid "Fires `sign_up` on new account registrations, including accounts created during WooCommerce checkout."
 msgstr ""
 
 #: assets/admin/996.js:1
+#: assets/admin/settings.js:10
 msgid "Search"
 msgstr ""
 
 #: assets/admin/996.js:1
+#: assets/admin/settings.js:10
 msgid "Fires `search` on WordPress and WooCommerce product search results pages."
 msgstr ""
 
@@ -2213,10 +2411,12 @@ msgid "Enable the Contact Form 7 integration first."
 msgstr ""
 
 #: assets/admin/996.js:1
+#: assets/admin/settings.js:10
 msgid "Generate lead (CF7)"
 msgstr ""
 
 #: assets/admin/996.js:1
+#: assets/admin/settings.js:10
 msgid "Fires `generate_lead` alongside the existing CF7 form event on successful Contact Form 7 submissions. Requires the Contact Form 7 integration to be enabled."
 msgstr ""
 
@@ -2266,119 +2466,923 @@ msgid "Got it"
 msgstr ""
 
 #: assets/admin/settings.js:1
+#: assets/admin/settings.js:18
+msgid "No patterns configured. GTM Kit loads on every frontend page."
+msgstr ""
+
+#: assets/admin/settings.js:1
+msgid "Pattern"
+msgstr ""
+
+#: assets/admin/settings.js:1
+msgid "Mode"
+msgstr ""
+
+#: assets/admin/settings.js:1
+#: assets/admin/settings.js:18
+msgid "Invalid regular expression."
+msgstr ""
+
+#: assets/admin/settings.js:1
+#: assets/admin/settings.js:18
+msgid "Invalid regular expression:"
+msgstr ""
+
+#: assets/admin/settings.js:1
+#: assets/admin/settings.js:18
+msgid "Glob"
+msgstr ""
+
+#: assets/admin/settings.js:1
+#: assets/admin/settings.js:18
+msgid "Regex"
+msgstr ""
+
+#: assets/admin/settings.js:1
+#: assets/admin/settings.js:18
+msgid "Remove pattern"
+msgstr ""
+
+#: assets/admin/settings.js:1
+#: assets/admin/settings.js:18
+msgid "Remove"
+msgstr ""
+
+#: assets/admin/settings.js:1
+msgid "Add pattern"
+msgstr ""
+
+#: assets/admin/settings.js:1
+#: assets/admin/settings.js:18
+msgid "Maximum of 100 patterns reached."
+msgstr ""
+
+#: assets/admin/settings.js:1
+#: assets/admin/settings.js:17
+msgid "(not set)"
+msgstr ""
+
+#. translators: %s is the name of the plugin.
+#: assets/admin/settings.js:4
+msgid "%s is not active"
+msgstr ""
+
+#. translators: %s is the name of the plugin.
+#: assets/admin/settings.js:7
+msgid "If you haven't installed and activated %s you must do that."
+msgstr ""
+
+#. translators: %s is the name of the plugin.
+#: assets/admin/settings.js:10
+msgid "Install %s"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "About this section"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Live dataLayer preview"
+msgstr ""
+
+#: assets/admin/settings.js:10
 msgid "Setup Integration"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 msgid "Get Template"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 msgid "Read More"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
+msgid "Retail"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Education"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Flights"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Hotel rental"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Jobs"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Local deals"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Real estate"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Travel"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Custom"
+msgstr ""
+
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "Settings saved successfully."
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "License validation failed. Please check your license key."
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "Network error. Please check your connection and try again."
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "Server error. Please try again later."
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "An unexpected error occurred. Please try again."
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 msgid "Save"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 msgid "Saved"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "Something went wrong"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "An unexpected error occurred. Please try refreshing the page."
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "Try Again"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "Reload Page"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "Section Error"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "The"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "section encountered an error. Other sections may still work normally."
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
 #: assets/admin/wizard.js:1
 msgid "This section encountered an error. Other sections may still work normally."
 msgstr ""
 
-#: assets/admin/settings.js:1
-msgid "Google Tag Manager Templates"
-msgstr ""
-
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:25
+#: assets/admin/settings.js:29
 msgid "Dashboard"
 msgstr ""
 
-#: assets/admin/settings.js:1
-msgid "Container"
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
+msgid "Setup"
 msgstr ""
 
-#: assets/admin/settings.js:1
-msgid "User data"
+#: assets/admin/settings.js:10
+msgid "Container, delivery and environment"
 msgstr ""
 
-#: assets/admin/settings.js:1
-msgid "Templates"
+#: assets/admin/settings.js:10
+msgid "Setup controls how the GTM container loads, the data layer name, server-side tagging, and which pages and roles are excluded from tracking."
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
+msgid "Read the setup guide"
+msgstr ""
+
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
+msgid "Events & data layer"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Post data, user data and engagement events"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "These settings control the page and user data GTM Kit adds to the data layer, plus the standard GA4 events it fires automatically, so your tags always have consistent variables to build on."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Read the events guide"
+msgstr ""
+
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
+msgid "Commerce"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "WooCommerce and Easy Digital Downloads tracking"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Commerce tracking pushes view_item, add_to_cart, begin_checkout and purchase events to the data layer for WooCommerce and EDD, ready for GA4 and Google Ads."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Read the commerce docs"
+msgstr ""
+
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
+msgid "Consent & privacy"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Consent Mode, script gating and CMP integration"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "You need a consent platform"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "These settings control the consent signals GTM Kit sends to Google Tag Manager. They do not ask visitors for consent. You need a Consent Management Platform (CMP) to collect and store consent choices."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "GTM Kit wires up these signals but is not responsible for your privacy compliance. Configuring consent correctly for your region is your responsibility: consult your own legal guidance."
+msgstr ""
+
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
+msgid "Tools"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Updates, logging and diagnostics"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "These tools help you keep GTM Kit healthy: control automatic updates, turn on logging when you need to debug, and choose whether to share anonymous usage data."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Read the troubleshooting guide"
+msgstr ""
+
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
+msgid "License"
+msgstr ""
+
+#: assets/admin/settings.js:10
+#: assets/admin/settings.js:29
 msgid "Support"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:10
+msgid "WooCommerce: Page data"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "WooCommerce: Basic Settings"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "WooCommerce: User Data"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "WooCommerce: Event Customization"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "WooCommerce: Webhooks for server-side tracking"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "WooCommerce: Google Ads Settings"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "WooCommerce: Advanced Settings"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "WooCommerce: Custom CSS Selectors"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Easy Digital Downloads: Basic Settings"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Easy Digital Downloads: Google Ads Settings"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Easy Digital Downloads: Advanced Settings"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Enable the Contact Form 7 integration."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Enable the WooCommerce integration."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "view_item_list (with product filter)"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Only push view_item_list once per page for each list."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Do you want to push the view_item_list event if the list is updated using a filter or just once per page view?"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "view_item (variable product)"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "add_shipping_info"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Disable the 'add_shipping_info' event."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "When do you want to fire the \"add_shipping_info\" event?"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "add_payment_info"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Include WooCommerce permalink structure"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Include path of WooCommerce pages"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Enable the Easy Digital Downloads integration."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the purchase event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Purchase webhook trigger"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "When an order is created."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "When the order is paid and status is Processing."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the order_paid event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the refund event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the order_processing event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the order_completed event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the order_refunded event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the subscription_started event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the subscription_renewed event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the subscription_cancelled event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the subscription_expired event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Send the subscription_reactivated event server-side"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Disable the frontend purchase event"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Disable the frontend subscription_started event"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Single Product (add_to_wishlist)"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Product List (select_item)"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Product List (add_to_wishlist)"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "third-party checkout"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "partner-hosted subpages"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "in-app webview routes"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "sGTM Hosting"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Server-side tagging improves data accuracy, performance, privacy, and flexibility."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Stape.io offers an affordable and user-friendly hosting solution for server-side Google Tag Manager containers."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Use GTM environments such as Live, Dev, or QA by entering the environment’s gtm_auth and gtm_preview values. If left empty, the default environment is used."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "These values can also be defined in wp-config.php"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Strong-block mode requires a consent signal to load GTM. With the Consent Mode master toggle off, GTM Kit emits no consent code itself; your CMP or custom code must fire the gtmkit:consent:updated event when consent is granted, otherwise GTM will not load."
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Plugin"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Gravity Forms"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Viewing:"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "All integrations"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Search all settings…"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Search all settings"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "Save changes"
+msgstr ""
+
+#: assets/admin/settings.js:10
+msgid "(Premium)"
+msgstr ""
+
+#. translators: %s: search query.
+#: assets/admin/settings.js:11
+msgid "Results for “%s”"
+msgstr ""
+
+#: assets/admin/settings.js:11
+msgid "No settings match your search."
+msgstr ""
+
+#: assets/admin/settings.js:17
+#: assets/admin/settings.js:18
+msgid "GTM Kit Premium"
+msgstr ""
+
+#. translators: %s: the product that unlocks this setting.
+#: assets/admin/settings.js:18
+msgid "Upgrade to %s to manage this setting here."
+msgstr ""
+
+#: assets/admin/settings.js:18
+msgid "Adds"
+msgstr ""
+
+#: assets/admin/settings.js:18
+msgid "to GTM Kit scripts."
+msgstr ""
+
+#: assets/admin/settings.js:18
+msgid "Name and value added as an attribute. Leave the name empty to omit it."
+msgstr ""
+
+#: assets/admin/settings.js:18
+msgid "Add pattern +"
+msgstr ""
+
+#: assets/admin/settings.js:18
+msgid "GTM Kit Woo Add-On"
+msgstr ""
+
+#. translators: %s: the add-on plugin name to update.
+#: assets/admin/settings.js:19
+msgid "Update %s to its latest version to manage this setting here."
+msgstr ""
+
+#: assets/admin/settings.js:19
+msgid "Promotion"
+msgstr ""
+
+#: assets/admin/settings.js:19
+msgid "Warning"
+msgstr ""
+
+#. translators: 1: integration name, 2: setting count, 3: capability name.
+#: assets/admin/settings.js:20
+msgid "Filtered to %1$s — %2$d settings in %3$s. Universal capabilities (Setup, Consent) still apply and stay available."
+msgstr ""
+
+#. translators: 1: integration name, 2: capability name.
+#: assets/admin/settings.js:21
+msgid "Filtered to %1$s. No %1$s settings in %2$s — universal settings still apply and stay available."
+msgstr ""
+
+#. translators: 1: hidden integration name, 2: active filter name.
+#: assets/admin/settings.js:22
+msgid "%1$s settings hidden by the %2$s filter."
+msgstr ""
+
+#: assets/admin/settings.js:22
+#: assets/admin/settings.js:24
+#: assets/admin/settings.js:25
+msgid "Off"
+msgstr ""
+
+#: assets/admin/settings.js:22
+msgid "Share anonymous data to help improve GTM Kit."
+msgstr ""
+
+#: assets/admin/settings.js:22
+#: assets/admin/settings.js:29
+msgid "Manage"
+msgstr ""
+
+#: assets/admin/settings.js:22
+msgid "Needs attention"
+msgstr ""
+
+#: assets/admin/settings.js:22
+msgid "You're all caught up. Nothing needs attention right now."
+msgstr ""
+
+#. translators: %d: number of dismissed notifications.
+#: assets/admin/settings.js:23
+msgid "Hide dismissed notifications (%d)"
+msgstr ""
+
+#. translators: %d: number of dismissed notifications.
+#: assets/admin/settings.js:24
+msgid "Show dismissed notifications (%d)"
+msgstr ""
+
+#: assets/admin/settings.js:24
+#: assets/admin/settings.js:29
+msgid "Container"
+msgstr ""
+
+#: assets/admin/settings.js:24
+msgid "Not set"
+msgstr ""
+
+#: assets/admin/settings.js:24
+msgid "Injected on all pages"
+msgstr ""
+
+#: assets/admin/settings.js:24
+msgid "Consent Mode v2"
+msgstr ""
+
+#: assets/admin/settings.js:24
+#: assets/admin/settings.js:25
+msgid "On"
+msgstr ""
+
+#. translators: %s: comma-separated region codes.
+#: assets/admin/settings.js:25
+msgid "Region: %s"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "All regions"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Server-side"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Webhook queue available"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Overview of your GTM Kit setup"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Set up your GTM container"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Recommended next step"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "GTM Kit is sending data to your container. Generate the Tags, Triggers and Variables you still need in Google Tag Manager."
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Open Template Assistant"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Resources"
+msgstr ""
+
+#: assets/admin/settings.js:25
+#: assets/admin/settings.js:29
+msgid "Read"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "All tutorials"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Browse the full guide library"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "What you configure here"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "This page is for enabling integrations and their basic plugin settings."
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Tracking itself, which events fire and what goes into the data layer, is configured on the capability pages (Commerce, Events & data layer, Consent & privacy)."
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Not installed"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Configure"
+msgstr ""
+
+#: assets/admin/settings.js:25
+msgid "Enable integrations here. Their settings live on the capability pages."
+msgstr ""
+
+#. translators: %s: capability name.
+#: assets/admin/settings.js:27
+msgid "Reached from Integrations · settings live under %s"
+msgstr ""
+
+#. translators: %s: integration name.
+#: assets/admin/settings.js:28
+msgid "Install and activate the %s plugin to configure this integration."
+msgstr ""
+
+#: assets/admin/settings.js:28
+msgid "Trouble activating?"
+msgstr ""
+
+#: assets/admin/settings.js:28
+msgid "Make sure the key is pasted in full (it starts with GTMK-) with no leading or trailing spaces, and that your server can reach the GTM Kit licensing server. If activation still fails, premium licence holders get priority email support and we can check it from our side."
+msgstr ""
+
+#: assets/admin/settings.js:28
+msgid "Contact premium support"
+msgstr ""
+
+#: assets/admin/settings.js:28
+msgid "Server-side webhooks & background queue"
+msgstr ""
+
+#: assets/admin/settings.js:28
+msgid "WooCommerce Subscriptions tracking"
+msgstr ""
+
+#: assets/admin/settings.js:28
+msgid "Event deferral until consent"
+msgstr ""
+
+#: assets/admin/settings.js:28
+msgid "Order attribution & enhanced conversions"
+msgstr ""
+
+#. translators: %s: license renewal date.
+#: assets/admin/settings.js:29
+msgid "Active · renews %s"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Your license"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "License key"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Status"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Deactivate license"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Unlock GTM Kit Premium"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Upgrade"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Server-side tracking, the webhook queue, subscriptions and more."
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Enter license key"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Activate license"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Buy a license"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Go to my account"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Get help and contact us"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Premium support"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Premium subscribers get direct email support, usually a same-day reply on weekdays. Bugs, configuration questions, edge cases."
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Contact support"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Get GTM Kit Premium"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Community support"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Free support in the WordPress.org support forum. Covers the plugin itself, not Google Tag Manager configuration."
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "WordPress support forum"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Bug reports"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Found a reproducible bug? Open an issue on GitHub with steps to reproduce and the plugin version. Public, searchable, faster to triage."
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Report on GitHub"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "If you have contacted support you may have been asked to share your system data. Enter the support ticket you have been given below."
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Support ticket"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "FS-12345"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Documentation"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "View all documentation"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Integration"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Google Tag Manager Templates"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "User data"
+msgstr ""
+
+#: assets/admin/settings.js:29
+msgid "Templates"
+msgstr ""
+
+#: assets/admin/settings.js:29
 msgid "Container Settings"
 msgstr ""
 
-#: assets/admin/settings.js:1
+#: assets/admin/settings.js:29
 msgid "Miscellaneous"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gtm-kit",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gtm-kit",
-      "version": "2.14.1",
+      "version": "2.15.0",
       "dependencies": {
         "@wordpress/api-fetch": "^7.33.1",
         "@wordpress/components": "^30.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtm-kit",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "Development files for the GTM Kit",
   "author": "GTM Kit",
   "keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://github.com/tlamedia/gtm-kit
 Tags: google tag manager, gtm, woocommerce, analytics, ga4
 Requires at least: 6.8
 Tested up to: 7.0
-Stable tag: 2.14.1
+Stable tag: 2.15.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -99,7 +99,11 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= Unreleased =
+= 2.15.0 =
+
+Release date: 2026-06-12
+
+Find out about what's new in our [our release post](https://gtmkit.com/gtm-kit-2-15/).
 
 #### Bugfixes:
 * Security hardening: Links served to the settings interface from remote content (upgrade offers, templates, tutorials) and notifications are now validated before they are used for navigation.
@@ -175,120 +179,6 @@ Find out about what's new in our [release post](https://gtmkit.com/gtm-kit-2-12/
 
 #### Other:
 * New `gtmkit_introductions` filter and `Introduction_Interface` contract let add-ons register their own announcement modals through a documented public API.
-
-= 2.11.0 =
-
-Release date: 2026-05-11
-
-Find out about what's new in our [release post](https://gtmkit.com/gtm-kit-2-11/).
-
-#### New:
-* "Exclude tax" toggle now controls every standard e-commerce event the data layer emits: `view_cart`, `begin_checkout`, `purchase`, variation prices on variable product pages (re-fired `view_item` + `add_to_cart`), and the per-item coupon `discount` field.
-
-#### Bugfixes:
-* Cart, checkout, variation, and coupon-discount events now follow the "Exclude tax" toggle consistently across `value`, `price`, and `discount` fields. The GTM Kit Woo and GTM Kit Premium add-ons extend the fix to refund and order-paid events in their paired releases.
-* Silence the "translation loading triggered too early" notice that WordPress 6.7+ logs against the `gtm-kit` text domain by registering translations at the very start of `init` before any other code can request a translated string.
-* Close an edge case where a script-dependency notice could still appear under WordPress 6.9.1+ when a consent or CMP plugin toggled the GTM Kit container active mid-request, by asking the WordPress script registry directly which scripts were actually registered instead of re-evaluating the container gate.
-
-#### Other:
-* Heads up: GA4 numbers may move after this update. Stores with prices entered ex-tax and tax-inclusive cart display will see `value` change from ex-tax to inc-tax in cart and checkout events.
-* New `gtmkit_resolve_tax_mode` and `gtmkit_resolve_item_discount` filters let developers override the toggle programmatically (per-event or per-context) and override the per-item coupon discount calculation.
-* Minimum required WordPress version is now 6.8 (was 6.7). Sites still on WordPress 6.7 won't get this update via the dashboard until they upgrade WordPress.
-
-= 2.10.1 =
-
-Release date: 2026-05-07
-
-Tag-only follow-up to 2.10.0 — completes the consent admin-badge surface alongside the React renderer that already shipped in 2.10.0. See the [2.10 release post](https://gtmkit.com/gtm-kit-2-10/) for the broader context.
-
-#### New:
-* New `gtmkit_consent_admin_badges` filter lets add-ons (e.g. Premium's WP Consent API integration) push status banners onto the Consent settings page so users see immediately when a higher-priority consent source has taken over.
-
-= 2.10.0 =
-
-Release date: 2026-05-06
-
-Find out about what's new in our [release post](https://gtmkit.com/gtm-kit-2-10/).
-
-#### New:
-* New "CMP script attributes" section on the Consent settings page lets you toggle Cookiebot, Iubenda, and CookieYes script-blocking attributes with one click and add a custom attribute for any other CMP — no PHP filters required.
-* Fresh installs auto-detect a known CMP plugin (Cookiebot, Iubenda, CookieYes) and pre-select the matching toggle so the right attribute is on from day one.
-* New "Script gating" mode on the Consent settings page lets you choose between always loading GTM, letting it load under Consent Mode v2 control, or holding it back entirely until consent is granted. Default stays as "Always load" so existing installs see no change.
-* Strong-block mode masks the Google Tag Manager container until visitors consent. Works alongside any CMP and falls back gracefully when no consent signal arrives.
-* Power users can override which consent categories must be granted before strong-block mode unmasks GTM via the new `gtmkit_strong_block_required_categories` filter.
-* `window.gtmkit.consent.state` exposes the current consent state so partner scripts and integrators can inspect it without subscribing to events.
-* New developer hooks let CMP integrations and consent add-ons plug into GTM Kit's consent flow without forking the plugin — sites running Cookiebot, CookieYes, WP Consent API or in-house consent solutions can now feed their state straight into GTM Kit.
-* Server-side broadcast `gtmkit_consent_updated` so other plugins can react to consent state changes without polling.
-* Per-event `gtmkit_event_should_defer` filter so future deferral features can hold individual events back when consent is missing.
-
-#### Bugfixes:
-* Eliminate "dependencies that are not registered: gtmkit-container" warnings logged by WordPress 6.9.1+ on sites that have GTM Kit's container active.
-
-#### Other:
-* The Cookiebot script attribute (`data-cookieconsent="ignore"`) is now configurable via Settings → Consent → CMP script attributes. Existing installs keep the attribute on by default to preserve current behavior; turn it off explicitly if you do not use Cookiebot.
-
-= 2.9.0 =
-
-Release date: 2026-04-29
-
-Find out about what's new in our [release post](https://gtmkit.com/gtm-kit-2-9/).
-
-#### Enhancements:
-* Scope Google Consent Mode defaults to specific countries or regions (e.g. DK, DE, US-CA) instead of applying them everywhere. Useful for sites with visitors both inside and outside the EU.
-* Consent updates from other plugins or partner scripts can now talk to GTM Kit through a simple JavaScript API, making CMP integrations easier.
-
-#### Bugfixes:
-* Webhooks for Server-side Tracking on the WooCommerce integrations page no longer stay locked after entering an sGTM Container Domain on premium installs.
-
-#### Other:
-* "Wait For Update" is now a proper number field with a sensible 500 ms default on new installs. Your existing value is kept.
-* Clearer warning on the Consent Mode page — if Cookiebot, Complianz, CookieYes, or Cookie Information already handles your consent, leave this setting off.
-* Introduced an internal automated test suite (PHPUnit + Vitest) and continuous integration across PHP 7.4–8.4 × WordPress 6.9. No functional change — every future release is now verified by unit and integration tests before shipping, raising the bar on quality and reliability.
-
-= 2.8.4 =
-
-Release date: 2026-04-23
-
-#### Other:
-* Declared compatibility with WooCommerce Product Object Caching (`product_instance_caching`) introduced in WooCommerce 10.5. No functional change; resolves the "incompatible plugins" notice in WooCommerce → Settings → Advanced → Features.
-* Tested up to WooCommerce 10.7.
-* Tested up to WordPress 7.0.
-
-= 2.8.3 =
-
-Release date: 2026-03-18
-
-#### Bugfixes:
-* Fix: Add error handling to WooCommerce blocks action handlers to prevent tracking errors from breaking checkout functionality or interfering with third-party plugins.
-
-#### Other:
-* Tested up to WooCommerce 10.6.
-
-= 2.8.2 =
-
-Release date: 2026-02-17
-
-#### Bugfixes:
-* Fix undefined array key warning for order-received query var in edge cases like certain payment gateway redirects or bot traffic.
-
-= 2.8.1 =
-
-Release date: 2026-01-30
-
-#### Bugfixes:
-* Fixes correct detection of the premium plugin.
-
-= 2.8.0 =
-
-Release date: 2026-01-29
-
-#### Enhancements:
-* Improved internal handling of plugin settings to make GTM Kit more reliable and easier to maintain, while ensuring full backward compatibility with existing configurations.
-
-#### Other:
-* Tested up to WooCommerce 10.5.
-* Require WooCommerce 9.5.
-
 
 = Earlier versions =
 For the changelog of earlier versions, please refer to [the changelog on gtmkit.com](https://gtmkit.com/changelog/).

--- a/src/scss/_tailwind-compiled.scss
+++ b/src/scss/_tailwind-compiled.scss
@@ -624,12 +624,32 @@ video {
   bottom: 2rem;
 }
 
+.gtmkit-left-0\.5 {
+  left: 0.125rem;
+}
+
 .gtmkit-right-0 {
   right: 0px;
 }
 
+.gtmkit-right-4 {
+  right: 1rem;
+}
+
 .gtmkit-right-8 {
   right: 2rem;
+}
+
+.gtmkit-top-0\.5 {
+  top: 0.125rem;
+}
+
+.gtmkit-top-4 {
+  top: 1rem;
+}
+
+.gtmkit-top-8 {
+  top: 2rem;
 }
 
 .gtmkit-z-10 {
@@ -663,6 +683,11 @@ video {
   margin-bottom: 4rem;
 }
 
+.gtmkit-my-3 {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
 .gtmkit-my-4 {
   margin-top: 1rem;
   margin-bottom: 1rem;
@@ -688,6 +713,10 @@ video {
 
 .gtmkit-mb-0\.5 {
   margin-bottom: 0.125rem;
+}
+
+.gtmkit-mb-1 {
+  margin-bottom: 0.25rem;
 }
 
 .gtmkit-mb-12 {
@@ -718,6 +747,10 @@ video {
   margin-bottom: 1.5rem;
 }
 
+.gtmkit-mb-7 {
+  margin-bottom: 1.75rem;
+}
+
 .gtmkit-mb-8 {
   margin-bottom: 2rem;
 }
@@ -732,6 +765,14 @@ video {
 
 .gtmkit-ml-6 {
   margin-left: 1.5rem;
+}
+
+.gtmkit-ml-auto {
+  margin-left: auto;
+}
+
+.gtmkit-mr-1 {
+  margin-right: 0.25rem;
 }
 
 .gtmkit-mr-2 {
@@ -770,6 +811,18 @@ video {
   margin-top: 2rem;
 }
 
+.gtmkit-mt-\[5px\] {
+  margin-top: 5px;
+}
+
+.gtmkit-mt-auto {
+  margin-top: auto;
+}
+
+.gtmkit-block {
+  display: block;
+}
+
 .gtmkit-inline-block {
   display: inline-block;
 }
@@ -794,8 +847,20 @@ video {
   height: 0.125rem;
 }
 
+.gtmkit-h-16 {
+  height: 4rem;
+}
+
+.gtmkit-h-2 {
+  height: 0.5rem;
+}
+
 .gtmkit-h-2\.5 {
   height: 0.625rem;
+}
+
+.gtmkit-h-4 {
+  height: 1rem;
 }
 
 .gtmkit-h-5 {
@@ -804,6 +869,22 @@ video {
 
 .gtmkit-h-8 {
   height: 2rem;
+}
+
+.gtmkit-h-9 {
+  height: 2.25rem;
+}
+
+.gtmkit-h-\[34px\] {
+  height: 34px;
+}
+
+.gtmkit-h-\[36px\] {
+  height: 36px;
+}
+
+.gtmkit-h-\[7px\] {
+  height: 7px;
 }
 
 .gtmkit-h-auto {
@@ -815,8 +896,16 @@ video {
   height: min-content;
 }
 
+.gtmkit-h-px {
+  height: 1px;
+}
+
 .gtmkit-max-h-96 {
   max-height: 24rem;
+}
+
+.gtmkit-min-h-5 {
+  min-height: 1.25rem;
 }
 
 .gtmkit-min-h-\[128px\] {
@@ -827,8 +916,20 @@ video {
   min-height: 175px;
 }
 
+.gtmkit-min-h-screen {
+  min-height: 100vh;
+}
+
+.gtmkit-w-2 {
+  width: 0.5rem;
+}
+
 .gtmkit-w-2\.5 {
   width: 0.625rem;
+}
+
+.gtmkit-w-4 {
+  width: 1rem;
 }
 
 .gtmkit-w-5 {
@@ -839,16 +940,64 @@ video {
   width: 2rem;
 }
 
+.gtmkit-w-9 {
+  width: 2.25rem;
+}
+
+.gtmkit-w-\[110px\] {
+  width: 110px;
+}
+
+.gtmkit-w-\[120px\] {
+  width: 120px;
+}
+
+.gtmkit-w-\[150px\] {
+  width: 150px;
+}
+
 .gtmkit-w-\[200px\] {
   width: 200px;
+}
+
+.gtmkit-w-\[240px\] {
+  width: 240px;
+}
+
+.gtmkit-w-\[248px\] {
+  width: 248px;
 }
 
 .gtmkit-w-\[250px\] {
   width: 250px;
 }
 
+.gtmkit-w-\[260px\] {
+  width: 260px;
+}
+
+.gtmkit-w-\[300px\] {
+  width: 300px;
+}
+
+.gtmkit-w-\[320px\] {
+  width: 320px;
+}
+
+.gtmkit-w-\[340px\] {
+  width: 340px;
+}
+
+.gtmkit-w-\[360px\] {
+  width: 360px;
+}
+
 .gtmkit-w-\[600px\] {
   width: 600px;
+}
+
+.gtmkit-w-\[7px\] {
+  width: 7px;
 }
 
 .gtmkit-w-fit {
@@ -858,6 +1007,14 @@ video {
 
 .gtmkit-w-full {
   width: 100%;
+}
+
+.gtmkit-w-px {
+  width: 1px;
+}
+
+.gtmkit-min-w-0 {
+  min-width: 0px;
 }
 
 .gtmkit-min-w-\[225px\] {
@@ -890,6 +1047,10 @@ video {
 
 .gtmkit-max-w-\[90vw\] {
   max-width: 90vw;
+}
+
+.gtmkit-max-w-full {
+  max-width: 100%;
 }
 
 .gtmkit-max-w-lg {
@@ -937,6 +1098,16 @@ video {
   table-layout: fixed;
 }
 
+.gtmkit-translate-x-0 {
+  --tw-translate-x: 0px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.gtmkit-translate-x-4 {
+  --tw-translate-x: 1rem;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
 @keyframes gtmkit-pulse {
   50% {
     opacity: .5;
@@ -945,6 +1116,14 @@ video {
 
 .gtmkit-animate-pulse {
   animation: gtmkit-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.gtmkit-cursor-default {
+  cursor: default;
+}
+
+.gtmkit-cursor-not-allowed {
+  cursor: not-allowed;
 }
 
 .gtmkit-cursor-pointer {
@@ -961,6 +1140,10 @@ video {
 
 .gtmkit-list-none {
   list-style-type: none;
+}
+
+.gtmkit-grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
 .gtmkit-grid-cols-2 {
@@ -991,6 +1174,10 @@ video {
   align-items: center;
 }
 
+.gtmkit-items-stretch {
+  align-items: stretch;
+}
+
 .\!gtmkit-justify-start {
   justify-content: flex-start !important;
 }
@@ -1007,8 +1194,16 @@ video {
   justify-content: space-between;
 }
 
+.gtmkit-gap-0\.5 {
+  gap: 0.125rem;
+}
+
 .gtmkit-gap-1 {
   gap: 0.25rem;
+}
+
+.gtmkit-gap-1\.5 {
+  gap: 0.375rem;
 }
 
 .gtmkit-gap-16 {
@@ -1019,12 +1214,24 @@ video {
   gap: 0.5rem;
 }
 
+.gtmkit-gap-2\.5 {
+  gap: 0.625rem;
+}
+
 .gtmkit-gap-3 {
   gap: 0.75rem;
 }
 
+.gtmkit-gap-3\.5 {
+  gap: 0.875rem;
+}
+
 .gtmkit-gap-4 {
   gap: 1rem;
+}
+
+.gtmkit-gap-5 {
+  gap: 1.25rem;
 }
 
 .gtmkit-gap-6 {
@@ -1035,6 +1242,14 @@ video {
   gap: 2rem;
 }
 
+.gtmkit-gap-\[14px\] {
+  gap: 14px;
+}
+
+.gtmkit-gap-\[5px\] {
+  gap: 5px;
+}
+
 .gtmkit-gap-x-16 {
   -moz-column-gap: 4rem;
        column-gap: 4rem;
@@ -1043,6 +1258,15 @@ video {
 .gtmkit-gap-x-2 {
   -moz-column-gap: 0.5rem;
        column-gap: 0.5rem;
+}
+
+.gtmkit-gap-x-6 {
+  -moz-column-gap: 1.5rem;
+       column-gap: 1.5rem;
+}
+
+.gtmkit-gap-y-3 {
+  row-gap: 0.75rem;
 }
 
 .gtmkit-space-x-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1063,16 +1287,34 @@ video {
   margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
 }
 
+.gtmkit-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.375rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.375rem * var(--tw-space-y-reverse));
+}
+
 .gtmkit-space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
 }
 
+.gtmkit-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.625rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.625rem * var(--tw-space-y-reverse));
+}
+
 .gtmkit-space-y-3 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(0.75rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(0.75rem * var(--tw-space-y-reverse));
+}
+
+.gtmkit-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.875rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.875rem * var(--tw-space-y-reverse));
 }
 
 .gtmkit-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1093,8 +1335,16 @@ video {
   margin-bottom: calc(2rem * var(--tw-space-y-reverse));
 }
 
+.gtmkit-self-start {
+  align-self: flex-start;
+}
+
 .gtmkit-overflow-auto {
   overflow: auto;
+}
+
+.gtmkit-overflow-hidden {
+  overflow: hidden;
 }
 
 .gtmkit-overflow-x-auto {
@@ -1109,6 +1359,18 @@ video {
   border-radius: 0.25rem;
 }
 
+.gtmkit-rounded-\[10px\] {
+  border-radius: 10px;
+}
+
+.gtmkit-rounded-\[6px\] {
+  border-radius: 6px;
+}
+
+.gtmkit-rounded-\[9px\] {
+  border-radius: 9px;
+}
+
 .gtmkit-rounded-full {
   border-radius: 9999px;
 }
@@ -1118,7 +1380,15 @@ video {
 }
 
 .gtmkit-rounded-md {
-  border-radius: 0.375rem;
+  border-radius: var(--gtmkit-radius-md, 8px);
+}
+
+.gtmkit-rounded-sm {
+  border-radius: var(--gtmkit-radius-sm, 4px);
+}
+
+.gtmkit-rounded-xl {
+  border-radius: 0.75rem;
 }
 
 .gtmkit-border {
@@ -1150,6 +1420,18 @@ video {
   border-bottom-width: 4px;
 }
 
+.gtmkit-border-l-\[3px\] {
+  border-left-width: 3px;
+}
+
+.gtmkit-border-r {
+  border-right-width: 1px;
+}
+
+.gtmkit-border-t {
+  border-top-width: 1px;
+}
+
 .gtmkit-border-t-0 {
   border-top-width: 0px;
 }
@@ -1158,9 +1440,22 @@ video {
   border-top-width: 4px;
 }
 
+.gtmkit-border-\[\#cfe0fb\] {
+  --tw-border-opacity: 1;
+  border-color: rgb(207 224 251 / var(--tw-border-opacity, 1));
+}
+
 .gtmkit-border-blue-200 {
   --tw-border-opacity: 1;
   border-color: rgb(191 219 254 / var(--tw-border-opacity, 1));
+}
+
+.gtmkit-border-border-default {
+  border-color: var(--gtmkit-color-border-default);
+}
+
+.gtmkit-border-brand-primary {
+  border-color: var(--gtmkit-color-brand-primary);
 }
 
 .gtmkit-border-color-border {
@@ -1195,6 +1490,10 @@ video {
   border-color: rgb(254 202 202 / var(--tw-border-opacity, 1));
 }
 
+.gtmkit-border-transparent {
+  border-color: transparent;
+}
+
 .gtmkit-border-white {
   --tw-border-opacity: 1;
   border-color: rgb(255 255 255 / var(--tw-border-opacity, 1));
@@ -1209,9 +1508,70 @@ video {
   border-bottom-color: var(--gtmkit-color-primary);
 }
 
+.gtmkit-bg-\[\#1d2327\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(29 35 39 / var(--tw-bg-opacity, 1));
+}
+
+.gtmkit-bg-\[\#c3c4c7\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(195 196 199 / var(--tw-bg-opacity, 1));
+}
+
+.gtmkit-bg-\[\#d63638\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(214 54 56 / var(--tw-bg-opacity, 1));
+}
+
+.gtmkit-bg-\[\#dba617\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(219 166 23 / var(--tw-bg-opacity, 1));
+}
+
+.gtmkit-bg-\[\#ececed\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(236 236 237 / var(--tw-bg-opacity, 1));
+}
+
+.gtmkit-bg-\[\#eff6ff\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
+}
+
+.gtmkit-bg-\[\#f0f0f1\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(240 240 241 / var(--tw-bg-opacity, 1));
+}
+
+.gtmkit-bg-\[\#fafafa\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(250 250 250 / var(--tw-bg-opacity, 1));
+}
+
+.gtmkit-bg-\[\#fcf3d6\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(252 243 214 / var(--tw-bg-opacity, 1));
+}
+
 .gtmkit-bg-blue-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
+}
+
+.gtmkit-bg-border-default {
+  background-color: var(--gtmkit-color-border-default);
+}
+
+.gtmkit-bg-brand-primary {
+  background-color: var(--gtmkit-color-brand-primary);
+}
+
+.gtmkit-bg-brand-surface-subtle {
+  background-color: var(--gtmkit-color-brand-surface-subtle);
+}
+
+.gtmkit-bg-chip-bg {
+  background-color: var(--gtmkit-color-chip-bg);
 }
 
 .gtmkit-bg-color-background-disabled {
@@ -1252,11 +1612,6 @@ video {
   background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
 }
 
-.gtmkit-bg-gray-300 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(209 213 219 / var(--tw-bg-opacity, 1));
-}
-
 .gtmkit-bg-gray-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
@@ -1272,6 +1627,14 @@ video {
   background-color: rgb(240 253 244 / var(--tw-bg-opacity, 1));
 }
 
+.gtmkit-bg-integration-woo-bg {
+  background-color: var(--gtmkit-color-integration-woo-bg);
+}
+
+.gtmkit-bg-page {
+  background-color: var(--gtmkit-color-bg-page);
+}
+
 .gtmkit-bg-red-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 242 242 / var(--tw-bg-opacity, 1));
@@ -1280,6 +1643,18 @@ video {
 .gtmkit-bg-red-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
+}
+
+.gtmkit-bg-surface {
+  background-color: var(--gtmkit-color-bg-surface);
+}
+
+.gtmkit-bg-tier-premium {
+  background-color: var(--gtmkit-color-tier-premium);
+}
+
+.gtmkit-bg-tier-premium-bg {
+  background-color: var(--gtmkit-color-tier-premium-bg);
 }
 
 .gtmkit-bg-transparent {
@@ -1316,6 +1691,10 @@ video {
   padding: 1rem;
 }
 
+.gtmkit-p-5 {
+  padding: 1.25rem;
+}
+
 .gtmkit-p-6 {
   padding: 1.5rem;
 }
@@ -1327,6 +1706,11 @@ video {
 .\!gtmkit-px-3 {
   padding-left: 0.75rem !important;
   padding-right: 0.75rem !important;
+}
+
+.\!gtmkit-px-4 {
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
 }
 
 .\!gtmkit-px-6 {
@@ -1342,6 +1726,11 @@ video {
 .\!gtmkit-py-1 {
   padding-top: 0.25rem !important;
   padding-bottom: 0.25rem !important;
+}
+
+.\!gtmkit-py-2 {
+  padding-top: 0.5rem !important;
+  padding-bottom: 0.5rem !important;
 }
 
 .\!gtmkit-py-4 {
@@ -1379,6 +1768,11 @@ video {
   padding-right: 0.75rem;
 }
 
+.gtmkit-px-3\.5 {
+  padding-left: 0.875rem;
+  padding-right: 0.875rem;
+}
+
 .gtmkit-px-4 {
   padding-left: 1rem;
   padding-right: 1rem;
@@ -1399,6 +1793,21 @@ video {
   padding-right: 2rem;
 }
 
+.gtmkit-px-\[10px\] {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.gtmkit-px-\[18px\] {
+  padding-left: 18px;
+  padding-right: 18px;
+}
+
+.gtmkit-px-\[7px\] {
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
 .gtmkit-py-0\.5 {
   padding-top: 0.125rem;
   padding-bottom: 0.125rem;
@@ -1407,6 +1816,11 @@ video {
 .gtmkit-py-1 {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
+}
+
+.gtmkit-py-1\.5 {
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
 }
 
 .gtmkit-py-12 {
@@ -1424,9 +1838,19 @@ video {
   padding-bottom: 0.75rem;
 }
 
+.gtmkit-py-3\.5 {
+  padding-top: 0.875rem;
+  padding-bottom: 0.875rem;
+}
+
 .gtmkit-py-4 {
   padding-top: 1rem;
   padding-bottom: 1rem;
+}
+
+.gtmkit-py-5 {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
 }
 
 .gtmkit-py-6 {
@@ -1434,25 +1858,82 @@ video {
   padding-bottom: 1.5rem;
 }
 
+.gtmkit-py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.gtmkit-py-\[18px\] {
+  padding-top: 18px;
+  padding-bottom: 18px;
+}
+
+.gtmkit-py-\[3px\] {
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+
+.gtmkit-py-\[5px\] {
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+.gtmkit-py-\[9px\] {
+  padding-top: 9px;
+  padding-bottom: 9px;
+}
+
 .gtmkit-py-px {
   padding-top: 1px;
   padding-bottom: 1px;
+}
+
+.gtmkit-pb-1\.5 {
+  padding-bottom: 0.375rem;
+}
+
+.gtmkit-pb-2 {
+  padding-bottom: 0.5rem;
+}
+
+.gtmkit-pb-4 {
+  padding-bottom: 1rem;
 }
 
 .gtmkit-pb-6 {
   padding-bottom: 1.5rem;
 }
 
+.gtmkit-pb-\[14px\] {
+  padding-bottom: 14px;
+}
+
 .gtmkit-pb-\[18px\] {
   padding-bottom: 18px;
+}
+
+.gtmkit-pb-\[22px\] {
+  padding-bottom: 22px;
 }
 
 .gtmkit-pl-5 {
   padding-left: 1.25rem;
 }
 
+.gtmkit-pr-4 {
+  padding-right: 1rem;
+}
+
+.gtmkit-pt-1 {
+  padding-top: 0.25rem;
+}
+
 .gtmkit-pt-3 {
   padding-top: 0.75rem;
+}
+
+.gtmkit-pt-3\.5 {
+  padding-top: 0.875rem;
 }
 
 .gtmkit-pt-4 {
@@ -1479,6 +1960,10 @@ video {
   text-align: center;
 }
 
+.gtmkit-font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 .\!gtmkit-text-base {
   font-size: 1rem !important;
   line-height: 1.5rem !important;
@@ -1499,8 +1984,28 @@ video {
   line-height: 2.5rem;
 }
 
+.gtmkit-text-\[11px\] {
+  font-size: 11px;
+}
+
+.gtmkit-text-\[12px\] {
+  font-size: 12px;
+}
+
+.gtmkit-text-\[13px\] {
+  font-size: 13px;
+}
+
 .gtmkit-text-\[15px\] {
   font-size: 15px;
+}
+
+.gtmkit-text-\[17px\] {
+  font-size: 17px;
+}
+
+.gtmkit-text-\[18px\] {
+  font-size: 18px;
 }
 
 .gtmkit-text-base {
@@ -1556,6 +2061,11 @@ video {
   font-style: italic;
 }
 
+.gtmkit-tabular-nums {
+  --tw-numeric-spacing: tabular-nums;
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction);
+}
+
 .gtmkit-leading-5 {
   line-height: 1.25rem;
 }
@@ -1564,9 +2074,54 @@ video {
   line-height: 1.125rem;
 }
 
+.gtmkit-leading-\[1\.45\] {
+  line-height: 1.45;
+}
+
+.gtmkit-leading-\[1\.5\] {
+  line-height: 1.5;
+}
+
+.gtmkit-leading-none {
+  line-height: 1;
+}
+
+.gtmkit-leading-normal {
+  line-height: 1.5;
+}
+
+.gtmkit-text-\[\#1a7f37\] {
+  --tw-text-opacity: 1;
+  color: rgb(26 127 55 / var(--tw-text-opacity, 1));
+}
+
+.gtmkit-text-\[\#7ee787\] {
+  --tw-text-opacity: 1;
+  color: rgb(126 231 135 / var(--tw-text-opacity, 1));
+}
+
+.gtmkit-text-\[\#8a6d00\] {
+  --tw-text-opacity: 1;
+  color: rgb(138 109 0 / var(--tw-text-opacity, 1));
+}
+
+.gtmkit-text-\[\#9a6700\] {
+  --tw-text-opacity: 1;
+  color: rgb(154 103 0 / var(--tw-text-opacity, 1));
+}
+
+.gtmkit-text-\[\#b32d2e\] {
+  --tw-text-opacity: 1;
+  color: rgb(179 45 46 / var(--tw-text-opacity, 1));
+}
+
 .gtmkit-text-blue-900 {
   --tw-text-opacity: 1;
   color: rgb(30 58 138 / var(--tw-text-opacity, 1));
+}
+
+.gtmkit-text-brand-primary {
+  color: var(--gtmkit-color-brand-primary);
 }
 
 .gtmkit-text-color-grey {
@@ -1606,14 +2161,43 @@ video {
   color: rgb(20 83 45 / var(--tw-text-opacity, 1));
 }
 
+.gtmkit-text-info {
+  color: var(--gtmkit-color-info);
+}
+
+.gtmkit-text-integration-woo {
+  color: var(--gtmkit-color-integration-woo);
+}
+
 .gtmkit-text-red-600 {
   --tw-text-opacity: 1;
   color: rgb(220 38 38 / var(--tw-text-opacity, 1));
 }
 
+.gtmkit-text-red-700 {
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
+}
+
 .gtmkit-text-red-900 {
   --tw-text-opacity: 1;
   color: rgb(127 29 29 / var(--tw-text-opacity, 1));
+}
+
+.gtmkit-text-text-muted {
+  color: var(--gtmkit-color-text-muted);
+}
+
+.gtmkit-text-text-primary {
+  color: var(--gtmkit-color-text-primary);
+}
+
+.gtmkit-text-text-secondary {
+  color: var(--gtmkit-color-text-secondary);
+}
+
+.gtmkit-text-tier-premium {
+  color: var(--gtmkit-color-tier-premium);
 }
 
 .gtmkit-text-white {
@@ -1627,6 +2211,10 @@ video {
 
 .gtmkit-opacity-100 {
   opacity: 1;
+}
+
+.gtmkit-opacity-50 {
+  opacity: 0.5;
 }
 
 .gtmkit-opacity-60 {
@@ -1671,17 +2259,36 @@ video {
   transition-duration: 150ms;
 }
 
+.gtmkit-transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .gtmkit-duration-500 {
   transition-duration: 500ms;
+}
+
+.first\:gtmkit-border-t-0:first-child {
+  border-top-width: 0px;
 }
 
 .hover\:gtmkit-border-color-grey:hover {
   border-color: var(--gtmkit-color-grey);
 }
 
-.hover\:gtmkit-bg-gray-400:hover {
+.hover\:gtmkit-bg-\[\#f6f7f7\]:hover {
   --tw-bg-opacity: 1;
-  background-color: rgb(156 163 175 / var(--tw-bg-opacity, 1));
+  background-color: rgb(246 247 247 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:gtmkit-bg-brand-surface-subtle:hover {
+  background-color: var(--gtmkit-color-brand-surface-subtle);
+}
+
+.hover\:gtmkit-bg-gray-200:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:gtmkit-bg-gray-700:hover {
@@ -1689,13 +2296,38 @@ video {
   background-color: rgb(55 65 81 / var(--tw-bg-opacity, 1));
 }
 
+.hover\:gtmkit-bg-page:hover {
+  background-color: var(--gtmkit-color-bg-page);
+}
+
 .hover\:gtmkit-bg-red-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(185 28 28 / var(--tw-bg-opacity, 1));
 }
 
+.hover\:gtmkit-text-color-heading:hover {
+  color: var(--gtmkit-text-color-heading);
+}
+
+.hover\:gtmkit-text-text-primary:hover {
+  color: var(--gtmkit-color-text-primary);
+}
+
 .hover\:gtmkit-underline:hover {
   text-decoration-line: underline;
+}
+
+.hover\:gtmkit-opacity-90:hover {
+  opacity: 0.9;
+}
+
+.focus\:gtmkit-border-brand-primary:focus {
+  border-color: var(--gtmkit-color-brand-primary);
+}
+
+.focus\:gtmkit-outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
 }
 
 .disabled\:\!gtmkit-bg-color-button-disabled:disabled {
@@ -1706,9 +2338,17 @@ video {
   color: var(--gtmkit-color-grey) !important;
 }
 
+.disabled\:gtmkit-opacity-50:disabled {
+  opacity: 0.5;
+}
+
 @media (min-width: 640px) {
   .sm\:gtmkit-w-auto {
     width: auto;
+  }
+
+  .sm\:gtmkit-grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -1732,6 +2372,10 @@ video {
   .md\:gtmkit-max-w-xl {
     max-width: 36rem;
   }
+
+  .md\:gtmkit-grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 @media (min-width: 1024px) {
@@ -1743,6 +2387,10 @@ video {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .lg\:gtmkit-grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
   .lg\:gtmkit-justify-between {
     justify-content: space-between;
   }
@@ -1751,5 +2399,55 @@ video {
 @media (min-width: 1280px) {
   .xl\:gtmkit-grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1440px) {
+  .min-\[1440px\]\:gtmkit-sticky {
+    position: sticky;
+  }
+
+  .min-\[1440px\]\:gtmkit-top-\[112px\] {
+    top: 112px;
+  }
+
+  .min-\[1440px\]\:gtmkit-block {
+    display: block;
+  }
+
+  .min-\[1440px\]\:gtmkit-flex {
+    display: flex;
+  }
+
+  .min-\[1440px\]\:gtmkit-w-\[400px\] {
+    width: 400px;
+  }
+
+  .min-\[1440px\]\:gtmkit-min-w-0 {
+    min-width: 0px;
+  }
+
+  .min-\[1440px\]\:gtmkit-max-w-\[1440px\] {
+    max-width: 1440px;
+  }
+
+  .min-\[1440px\]\:gtmkit-flex-1 {
+    flex: 1 1 0%;
+  }
+
+  .min-\[1440px\]\:gtmkit-shrink-0 {
+    flex-shrink: 0;
+  }
+
+  .min-\[1440px\]\:gtmkit-items-start {
+    align-items: flex-start;
+  }
+
+  .min-\[1440px\]\:gtmkit-gap-6 {
+    gap: 1.5rem;
+  }
+
+  .min-\[1440px\]\:gtmkit-self-start {
+    align-self: flex-start;
   }
 }


### PR DESCRIPTION
## Summary

Cuts gtm-kit 2.15.0. Headline scope:

- Security hardening: links served to the settings interface from remote content (upgrade offers, templates, tutorials) and notifications are now validated before they are used for navigation.
- New `gtmkit_settings_registry` filter lets add-ons register their settings fields with the GTM Kit settings screen at runtime; the settings screen now exposes its field registry and related metadata.

Version bump:
- gtm-kit.php — Version header + GTMKIT_VERSION constant
- readme.txt — Stable tag 2.15.0 + canonical = 2.15.0 = block linked to gtmkit.com/gtm-kit-2-15/
- package.json + package-lock.json — 2.15.0

Translation template: languages/gtm-kit.pot regenerated, Project-Id-Version: GTM Kit 2.15.0, 185 new strings (from the rebuilt settings bundle).

Assets rebuilt:
- assets/frontend/consent-gating.js — 969/1024 bytes minified, bundle-size guard green
- assets/frontend/woocommerce-blocks.* — wp-scripts blocks bundle
- assets/admin/* — React admin app from gtm-kit-settings
- Asset delta against main is empty: the feature PRs had already committed the current bundles.

Also includes a small source sync: the compiled Tailwind utilities file that the shipped admin CSS was built from is now committed, so the settings/wizard CSS is reproducible from source.

Tested up to headers: already current (WordPress 7.0, WooCommerce 10.8.1), no change needed.

Dependency audit (read-only): composer audit clean. npm audit reports a moderate advisory in `uuid` via `@wordpress/components` (build-time dependency, not shipped to users); the fix is a breaking major bump and is deferred to a separate maintenance PR.

## Quality gates
- [x] composer phpstan — 0 errors
- [x] composer phpcs — 0 errors, 0 warnings
- [x] PHPUnit unit + integration — 99/99 and 90/90 tests pass (1 skipped, environment-dependent)
- [x] Vitest — 100/100 tests pass
- [x] consent-gating bundle size — 969 / 1024 bytes
- [x] readme.txt changelog retention — bin/check-readme-changelog.sh PASS
- [x] Shipped-code review for fatal errors and serious bugs — clean (PHP diff reviewed by hand; settings-app JS diff reviewed in depth incl. the URL validation, which fails closed; 215 settings unit tests green)

## Test plan
- [x] On the local site, open Settings → GTM Kit and confirm the dashboard, settings pages, and notifications render and navigate correctly (the URL validation now gates remote-content links).
- [x] With GTM Kit Premium active, confirm the add-on settings fields registered through the new filter appear on the settings screen.
- [x] Verify the plugin version shows 2.15.0 in the plugins list and the changelog renders correctly in the wp.org "View details" modal after release.