### PR TITLE
Add option-value read filter and opt-in settings-shell flag

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 
 Unreleased
 * Fix: The Contact Form 7 "Load JavaScript" setting now shows the recommended choice as selected when the setting has never been saved.
+* Dev: New `gtmkit_option_value` filter runs on every option read, including unknown keys, so add-ons can resolve a value from an alternative source (for example a network-level override) without changing the core read path.
+* Dev: New `gtmkit_shell_v2` filter opts a site into GTM Kit's new settings interface and doubles as a kill-switch; while it is active the settings admin menu collapses to a single entry. The classic settings interface remains the default.
 
 2026-06-12 - version 2.15.0
 * Fix: Security hardening. Links served to the settings interface from remote content (upgrade offers, templates, tutorials) and notifications are now validated before they are used for navigation.

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 #### Bugfixes:
 * The Contact Form 7 "Load JavaScript" setting now shows the recommended choice as selected when the setting has never been saved.
 
+#### Other:
+* New `gtmkit_option_value` filter runs on every option read, including unknown keys, so add-ons can resolve a value from an alternative source (for example a network-level override) without changing the core read path.
+* New `gtmkit_shell_v2` filter opts a site into GTM Kit's new settings interface and doubles as a kill-switch; while it is active the settings admin menu collapses to a single entry. The classic settings interface remains the default.
+
 = 2.15.0 =
 
 Release date: 2026-06-12

--- a/src/Admin/AbstractOptionsPage.php
+++ b/src/Admin/AbstractOptionsPage.php
@@ -85,9 +85,35 @@ abstract class AbstractOptionsPage {
 	abstract protected static function create_instance( Options $options, Util $util ): AbstractOptionsPage;
 
 	/**
+	 * Whether the capability-axis settings shell is the active admin UI.
+	 *
+	 * Defaults to the legacy per-page UI; flip with the `gtmkit_shell_v2`
+	 * filter, which doubles as a kill-switch. When the shell is active it owns
+	 * in-app navigation, so the WP admin submenu collapses to the single
+	 * top-level entry and the standalone settings sub-pages are not registered.
+	 *
+	 * @return bool
+	 */
+	public static function is_shell_v2_active(): bool {
+		/**
+		 * Filters whether the capability-axis settings shell is the active
+		 * admin UI. Defaults to false (the legacy per-page UI).
+		 *
+		 * @param bool $active Whether the shell is active.
+		 */
+		return (bool) apply_filters( 'gtmkit_shell_v2', false );
+	}
+
+	/**
 	 * Adds the admin page to the menu.
 	 */
 	public function add_admin_page(): void {
+		// With the shell active the single top-level entry hosts every page, so
+		// the per-page submenu entries are redundant.
+		if ( self::is_shell_v2_active() ) {
+			return;
+		}
+
 		add_submenu_page(
 			$this->get_parent_slug(),
 			$this->get_page_title(),

--- a/src/Admin/GeneralOptionsPage.php
+++ b/src/Admin/GeneralOptionsPage.php
@@ -152,6 +152,7 @@ final class GeneralOptionsPage extends AbstractOptionsPage {
 			[
 				'rootId'             => 'gtmkit-settings',
 				'currentPage'        => $page_slug,
+				'shellV2'            => self::is_shell_v2_active(),
 				'version'            => GTMKIT_VERSION,
 				'root'               => \esc_url_raw( rest_url() ),
 				'nonce'              => \wp_create_nonce( 'wp_rest' ),

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -125,12 +125,26 @@ final class Options {
 		} elseif ( $map ) {
 			$value = $map['default'];
 		} else {
-			return null;
+			$value = null;
 		}
 
-		return is_string( $value ) && $strip_slashes && ! $this->is_const_defined( $group, $key )
-			? stripslashes( $value )
-			: $value;
+		if ( is_string( $value ) && $strip_slashes && ! $this->is_const_defined( $group, $key ) ) {
+			$value = stripslashes( $value );
+		}
+
+		/**
+		 * Filters a resolved option value as it leaves the read path.
+		 *
+		 * Fires for every read, including the not-found case where `$value` is
+		 * null, so a listener can supply the value from an alternative store
+		 * (for example a network-level override) without the core read path
+		 * needing to know about it.
+		 *
+		 * @param mixed  $value The resolved value, or null when the key is unknown.
+		 * @param string $group The option group.
+		 * @param string $key   The option key.
+		 */
+		return apply_filters( 'gtmkit_option_value', $value, $group, $key );
 	}
 
 	/**


### PR DESCRIPTION
Two small, additive seams that prepare the new capability-axis settings interface for a later cutover. Both default to today's behaviour, so this is a no-op for every existing site until a developer opts in.

## What changed

**`gtmkit_option_value` read filter.** `Options::get()` now passes its resolved value through `apply_filters( 'gtmkit_option_value', $value, $group, $key )` on every read. The filter also fires for unknown keys (where the value is `null`), so an add-on can supply a value from an alternative source (for example a network-level override) without the core read path needing to know about it. `get()` was unified to a single filtered return; behaviour is otherwise unchanged.

**`gtmkit_shell_v2` flag + kill-switch.** A new `apply_filters( 'gtmkit_shell_v2', false )` flag, exposed to the settings screen as `window.gtmkitSettings.shellV2`, opts a site into the new settings interface and doubles as a kill-switch. **It defaults to the classic per-page UI.** While the flag is active, the WP admin submenu collapses to the single top-level GTM Kit entry (the new interface owns in-app navigation); the notification bubble is preserved. With the flag off, all existing submenu entries register exactly as before.

## Test plan

All verified on a local site (admin UI + wp-cli).

- [x] With no filters set, open the GTM Kit admin menu: all five submenu entries (General, Integrations, GTM Templates, Upgrades, Help) appear with the notification bubble, and each page loads as before.
- [x] Settings still read and save normally with the filter attached (the option-value filter is a no-op with no listener): toggled a setting in the UI, confirmed it persisted to the database, and confirmed the filtered `get()` returned the saved value.
- [x] With `add_filter( 'gtmkit_shell_v2', '__return_true' );`: the GTM Kit submenu collapses to a single entry, the notification bubble still shows, the interface renders, and there are no console errors.
- [x] A `gtmkit_option_value` listener can both override a known value and supply a value for an otherwise-unknown key (verified via wp-cli; unknown keys still return `null` with no listener attached).