### PR TITLE
Changelog: Post data field copy fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 Unreleased
 * Fix: The Contact Form 7 "Load JavaScript" setting now shows the recommended choice as selected when the setting has never been saved.
+* Fix: On the Post data settings, the Post title option showed the Post ID help text and the Post date option was mislabelled "Post data". Both now read correctly.
 * Dev: New `gtmkit_option_value` filter runs on every option read, including unknown keys, so add-ons can resolve a value from an alternative source (for example a network-level override) without changing the core read path.
 * Dev: New `gtmkit_shell_v2` filter opts a site into GTM Kit's new settings interface and doubles as a kill-switch; while it is active the settings admin menu collapses to a single entry. The classic settings interface remains the default.
 

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 #### Bugfixes:
 * The Contact Form 7 "Load JavaScript" setting now shows the recommended choice as selected when the setting has never been saved.
+* On the Post data settings, the Post title option showed the Post ID help text and the Post date option was mislabelled "Post data". Both now read correctly.
 
 #### Other:
 * New `gtmkit_option_value` filter runs on every option read, including unknown keys, so add-ons can resolve a value from an alternative source (for example a network-level override) without changing the core read path.


### PR DESCRIPTION
Records the user-facing copy fix for the Post data settings (Post title help text and Post date label). The code change lives in the settings UI source and ships with the bundle rebuilt at the next release; this adds the matching `Unreleased` changelog and readme entries.

## Test plan

- [x] Changelog and readme `Unreleased` blocks updated; no code changes.