### PR TITLE
Default to the redesigned settings interface

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,9 @@
 *** GTM Kit ***
 
 Unreleased
+* Changed: The settings screen now uses the redesigned, capability-based interface by default, with settings grouped into Setup, Events & data layer, Commerce, Consent & privacy, Tools and more. The previous layout stays available as a fallback: append `?gtmkit_shell=v1` to a settings URL for a single visit, or use the `gtmkit_shell_v2` filter to switch a whole site back.
 * Fix: The Contact Form 7 "Load JavaScript" setting now shows the recommended choice as selected when the setting has never been saved.
 * Dev: New `gtmkit_option_value` filter runs on every option read, including unknown keys, so add-ons can resolve a value from an alternative source (for example a network-level override) without changing the core read path.
-* Dev: New `gtmkit_shell_v2` filter opts a site into GTM Kit's new settings interface and doubles as a kill-switch; while it is active the settings admin menu collapses to a single entry. The classic settings interface remains the default.
 
 2026-06-12 - version 2.15.0
 * Fix: Security hardening. Links served to the settings interface from remote content (upgrade offers, templates, tutorials) and notifications are now validated before they are used for navigation.

--- a/readme.txt
+++ b/readme.txt
@@ -101,12 +101,14 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = Unreleased =
 
+#### New:
+* The settings screen now uses a redesigned, capability-based interface by default, organising everything into Setup, Events & data layer, Commerce, Consent & privacy, Tools and more. The previous layout stays available as a fallback: append ?gtmkit_shell=v1 to a settings URL for a single visit, or use the gtmkit_shell_v2 filter to switch a whole site back.
+
 #### Bugfixes:
 * The Contact Form 7 "Load JavaScript" setting now shows the recommended choice as selected when the setting has never been saved.
 
 #### Other:
 * New `gtmkit_option_value` filter runs on every option read, including unknown keys, so add-ons can resolve a value from an alternative source (for example a network-level override) without changing the core read path.
-* New `gtmkit_shell_v2` filter opts a site into GTM Kit's new settings interface and doubles as a kill-switch; while it is active the settings admin menu collapses to a single entry. The classic settings interface remains the default.
 
 = 2.15.0 =
 

--- a/src/Admin/AbstractOptionsPage.php
+++ b/src/Admin/AbstractOptionsPage.php
@@ -87,21 +87,41 @@ abstract class AbstractOptionsPage {
 	/**
 	 * Whether the capability-axis settings shell is the active admin UI.
 	 *
-	 * Defaults to the legacy per-page UI; flip with the `gtmkit_shell_v2`
-	 * filter, which doubles as a kill-switch. When the shell is active it owns
-	 * in-app navigation, so the WP admin submenu collapses to the single
-	 * top-level entry and the standalone settings sub-pages are not registered.
+	 * Defaults to the shell. Turn it off site-wide with the `gtmkit_shell_v2`
+	 * filter (`__return_false`), which doubles as a kill-switch. A
+	 * `?gtmkit_shell=v1` or `?gtmkit_shell=v2` request parameter overrides the
+	 * default for that request in either direction, a symmetric per-request
+	 * escape hatch for spot-checking or a quick rollback. When the shell is
+	 * active it owns in-app navigation, so the WP admin submenu collapses to the
+	 * single top-level entry and the standalone settings sub-pages are not
+	 * registered.
 	 *
 	 * @return bool
 	 */
 	public static function is_shell_v2_active(): bool {
+		// A ?gtmkit_shell=v1|v2 request parameter wins over the default, so the
+		// previous UI can be reached without changing site configuration. This
+		// is a read-only display preference, so no nonce check applies.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['gtmkit_shell'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$requested = sanitize_key( wp_unslash( $_GET['gtmkit_shell'] ) );
+			if ( 'v1' === $requested ) {
+				return false;
+			}
+			if ( 'v2' === $requested ) {
+				return true;
+			}
+		}
+
 		/**
 		 * Filters whether the capability-axis settings shell is the active
-		 * admin UI. Defaults to false (the legacy per-page UI).
+		 * admin UI. Defaults to true (the redesigned settings interface);
+		 * return false to fall back to the legacy per-page UI.
 		 *
 		 * @param bool $active Whether the shell is active.
 		 */
-		return (bool) apply_filters( 'gtmkit_shell_v2', false );
+		return (bool) apply_filters( 'gtmkit_shell_v2', true );
 	}
 
 	/**


### PR DESCRIPTION
Makes the redesigned, capability-based settings interface the default. Everything it relies on already shipped — the `gtmkit_shell_v2` flag, the client flag logic, the submenu collapse, the legacy-route redirects, and the current built bundle — so this only changes the PHP default and adds a symmetric escape hatch. No bundle change.

## What changed

`AbstractOptionsPage::is_shell_v2_active()`:
- Default flips from `false` to `true`, so `window.gtmkitSettings.shellV2` localizes truthy and the WP admin submenu collapses to a single entry by default.
- A `?gtmkit_shell=v1` or `?gtmkit_shell=v2` request parameter overrides the default for that request in either direction — a symmetric, per-request escape hatch. The parameter wins over the default (and over a kill filter), so `?gtmkit_shell=v1` gives a coherent legacy view with the full submenu restored.
- The `gtmkit_shell_v2` filter remains the site-wide kill-switch: `add_filter( 'gtmkit_shell_v2', '__return_false' )` returns a whole site to the previous interface.

Reversible at every level (parameter, filter) with no deploy. Old UI is untouched and still reachable.

## Test plan

Verified on a local site (wp-cli, deterministic):

- [x] No filter / no parameter → shell active (`is_shell_v2_active()` true), WP submenu collapses to **1** entry.
- [x] `?gtmkit_shell=v1` → legacy active (false), submenu restored to **5** entries.
- [x] `add_filter( 'gtmkit_shell_v2', '__return_false' )` → legacy active, submenu **5** entries.
- [x] `?gtmkit_shell=v2` wins even when the kill filter is set → shell active.
- [x] Visual smoke check in the browser: with the dogfood localStorage cleared, the new shell renders by default and the WP submenu collapses to one entry; `?gtmkit_shell=v1` restores the classic UI and the full 5-entry submenu.
