### PR TITLE
Keep AbstractOptionsPage::add_admin_page() concrete for add-on subclasses

### DIFF
--- a/src/Admin/AbstractOptionsPage.php
+++ b/src/Admin/AbstractOptionsPage.php
@@ -87,10 +87,22 @@ abstract class AbstractOptionsPage {
 	/**
 	 * Adds the admin page to the menu.
 	 *
-	 * The settings shell owns in-app navigation, so a single top-level entry
-	 * hosts every page; the concrete page registers that entry here.
+	 * The settings shell owns in-app navigation, so the concrete top-level page
+	 * overrides this to register a single menu entry. The default submenu
+	 * registration is kept concrete so add-ons that subclass this base against
+	 * an older core (and do not override it) keep loading without a fatal.
 	 */
-	abstract public function add_admin_page(): void;
+	public function add_admin_page(): void {
+		add_submenu_page(
+			$this->get_parent_slug(),
+			$this->get_page_title(),
+			$this->get_menu_title(),
+			$this->get_capability(),
+			$this->get_menu_slug(),
+			[ $this, 'render' ],
+			$this->get_position()
+		);
+	}
 
 	/**
 	 * Renders the admin page.
@@ -145,6 +157,15 @@ abstract class AbstractOptionsPage {
 	 * @return string
 	 */
 	abstract protected function get_parent_slug(): string;
+
+	/**
+	 * The position in the menu order this item should appear.
+	 *
+	 * @return int|null
+	 */
+	protected function get_position(): ?int {
+		return null;
+	}
 
 	/**
 	 * Enqueue admin page scripts and styles.

--- a/tests/phpunit/Unit/Admin/AbstractOptionsPageBackwardCompatTest.php
+++ b/tests/phpunit/Unit/Admin/AbstractOptionsPageBackwardCompatTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Backward-compatibility guard for {@see AbstractOptionsPage}.
+ *
+ * Add-ons subclass this base against whatever core is active at runtime, and
+ * core auto-updates ahead of them. A published add-on page implements only the
+ * abstract members and inherits add_admin_page(); if that method becomes
+ * abstract again, the add-on class can no longer be declared and the admin
+ * screen fatals on the next page load. These tests lock add_admin_page() (and
+ * its get_position() dependency) as concrete so such a subclass keeps loading.
+ *
+ * @package TLA_Media\GTM_Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Tests\Unit\Admin;
+
+use ReflectionMethod;
+use TLA_Media\GTM_Kit\Admin\AbstractOptionsPage;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+require_once __DIR__ . '/fixtures/BackwardCompatFixtureOptionsPage.php';
+
+/**
+ * Guards that AbstractOptionsPage stays subclassable by add-on pages that do
+ * not override add_admin_page().
+ */
+final class AbstractOptionsPageBackwardCompatTest extends TestCase {
+
+	/**
+	 * Keeps add_admin_page() concrete so add-on subclasses can inherit it.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Admin\AbstractOptionsPage::add_admin_page
+	 */
+	public function test_add_admin_page_stays_concrete(): void {
+		$method = new ReflectionMethod( AbstractOptionsPage::class, 'add_admin_page' );
+
+		$this->assertFalse(
+			$method->isAbstract(),
+			'add_admin_page() must stay concrete; making it abstract fatals add-on pages built against an older core.'
+		);
+	}
+
+	/**
+	 * Keeps get_position() as a concrete method add_admin_page() can call.
+	 *
+	 * @covers \TLA_Media\GTM_Kit\Admin\AbstractOptionsPage::get_position
+	 */
+	public function test_get_position_stays_concrete(): void {
+		$this->assertTrue(
+			method_exists( AbstractOptionsPage::class, 'get_position' ),
+			'get_position() must exist; add_admin_page() passes it to add_submenu_page().'
+		);
+		$this->assertFalse(
+			( new ReflectionMethod( AbstractOptionsPage::class, 'get_position' ) )->isAbstract()
+		);
+	}
+
+	/**
+	 * Confirms a subclass implementing only the abstract members is declarable.
+	 */
+	public function test_subclass_without_add_admin_page_is_declarable(): void {
+		$this->assertTrue( class_exists( BackwardCompatFixtureOptionsPage::class ) );
+	}
+}

--- a/tests/phpunit/Unit/Admin/fixtures/BackwardCompatFixtureOptionsPage.php
+++ b/tests/phpunit/Unit/Admin/fixtures/BackwardCompatFixtureOptionsPage.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Test fixture: a minimal options page for the AbstractOptionsPage
+ * backward-compatibility guard.
+ *
+ * @package TLA_Media\GTM_Kit
+ */
+
+namespace TLA_Media\GTM_Kit\Tests\Unit\Admin;
+
+use TLA_Media\GTM_Kit\Admin\AbstractOptionsPage;
+use TLA_Media\GTM_Kit\Common\Util;
+use TLA_Media\GTM_Kit\Options\Options;
+
+/**
+ * A minimal options page implementing only AbstractOptionsPage's abstract
+ * members, mirroring an add-on page (e.g. TemplatesOptionsPagePro) built against
+ * the base class. Declaring this class is itself a guard: were add_admin_page()
+ * abstract again, PHP would fatal loading this file.
+ */
+final class BackwardCompatFixtureOptionsPage extends AbstractOptionsPage {
+
+	/**
+	 * Build the page instance.
+	 *
+	 * @param Options $options Options.
+	 * @param Util    $util Utilities.
+	 */
+	protected static function create_instance( Options $options, Util $util ): AbstractOptionsPage {
+		return new self( $options, $util );
+	}
+
+	/**
+	 * Configure the page.
+	 */
+	public function configure(): void {}
+
+	/**
+	 * Enqueue assets.
+	 *
+	 * @param mixed $hook Current hook.
+	 */
+	public function enqueue_page_assets( $hook ): void {}
+
+	/**
+	 * Localize script.
+	 *
+	 * @param string $page_slug Page slug.
+	 * @param string $script_handle Script handle.
+	 */
+	public function localize_script( string $page_slug, string $script_handle ): void {}
+
+	/**
+	 * Menu slug.
+	 */
+	protected function get_menu_slug(): string {
+		return 'gtmkit_fixture';
+	}
+
+	/**
+	 * Page title.
+	 */
+	protected function get_page_title(): string {
+		return 'Fixture';
+	}
+
+	/**
+	 * Parent slug.
+	 */
+	protected function get_parent_slug(): string {
+		return 'gtmkit_general';
+	}
+}


### PR DESCRIPTION
## Summary

Restores backward compatibility for add-on option pages, which 2.16.0 would otherwise crash.

The settings redesign made `AbstractOptionsPage::add_admin_page()` abstract and removed `get_position()`. Add-on option pages (gtm-kit-woo and gtm-kit-premium's `TemplatesOptionsPagePro`) subclass this base and implement only the abstract members, inheriting `add_admin_page()`. Because GTM Kit core auto-updates ahead of the add-ons, an installed older add-on then contains an unimplemented abstract method and fatals on the admin screen the moment core updates:

```
Fatal error: Class TLA_Media\GTM_Kit\Woo\Admin\TemplatesOptionsPagePro contains 1 abstract method
and must therefore be declared abstract or implement the remaining method
(TLA_Media\GTM_Kit\Admin\AbstractOptionsPage::add_admin_page)
```

Reproduced against the currently published gtm-kit-woo 1.7.0 and gtm-kit-premium 1.0.0.

## Fix

- `AbstractOptionsPage::add_admin_page()` is concrete again (its prior submenu-registration default), and `get_position()` is restored.
- `GeneralOptionsPage` still overrides `add_admin_page()` with the single top-level menu entry, so the redesigned admin UI is unchanged. The concrete base default only exists so older add-on subclasses keep loading.

## Tests

- New unit test locks `add_admin_page()` and `get_position()` as concrete and declares a subclass that omits `add_admin_page()` (the add-on pattern) to prove it stays loadable.
- Verified before/after: the unfixed base reproduces the fatal when loading the published add-on classes; the fixed base loads both cleanly.

## Quality gates
- [x] composer phpstan — 0 errors
- [x] composer phpcs — 0 errors, 0 warnings
- [x] PHPUnit unit — 102/102 (3 new)
- [x] PHPUnit integration — 90/90 (1 documented skip)
