### PR TITLE
Fix: Commerce Brand selector shows only "(not set)"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** GTM Kit ***
 
+Unreleased
+* Fix: The Commerce "Brand" selector now lists your product brand taxonomies again, instead of showing only "(not set)". The redesigned settings screen stopped loading the taxonomy and page lists, so the Brand selector (and other taxonomy- or page-based options) appeared empty regardless of how brands were configured.
+
 2026-06-23 - version 2.16.0
 * Add: The settings screen now uses a redesigned, capability-based interface, organising everything into Setup, Events & data layer, Commerce, Consent & privacy, Tools and more.
 * Fix: The Contact Form 7 "Load JavaScript" setting now shows the recommended choice as selected when the setting has never been saved.

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,11 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= Unreleased =
+
+#### Bugfixes:
+* The Commerce "Brand" selector now lists your product brand taxonomies again, instead of showing only "(not set)". The redesigned settings screen stopped loading the taxonomy and page lists, so the Brand selector (and other taxonomy- or page-based options) appeared empty regardless of how brands were configured.
+
 = 2.16.0 =
 
 Release date: 2026-06-23

--- a/src/Admin/GeneralOptionsPage.php
+++ b/src/Admin/GeneralOptionsPage.php
@@ -159,6 +159,8 @@ final class GeneralOptionsPage extends AbstractOptionsPage {
 			'notifications'      => $this->get_notifications(),
 			'consentAdminBadges' => $this->get_consent_admin_badges(),
 			'settingsRegistry'   => $this->get_settings_registry(),
+			'taxonomyOptions'    => $this->get_taxonomy_options(),
+			'pageOptions'        => $this->get_page_options(),
 		];
 
 		/**
@@ -253,6 +255,68 @@ final class GeneralOptionsPage extends AbstractOptionsPage {
 		}
 
 		return $normalised;
+	}
+
+	/**
+	 * Build the list of public, UI-visible custom taxonomies offered as
+	 * options for taxonomy-backed settings such as the WooCommerce brand
+	 * source. Built-in taxonomies are excluded so the list stays focused on
+	 * the taxonomies a store actually uses to classify products.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	private function get_taxonomy_options(): array {
+		$taxonomies = get_taxonomies(
+			[
+				'show_ui'  => true,
+				'public'   => true,
+				'_builtin' => false,
+			],
+			'objects'
+		);
+
+		$taxonomy_options = [];
+
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( is_object( $taxonomy ) && property_exists( $taxonomy, 'label' ) && property_exists( $taxonomy, 'name' ) ) {
+				$taxonomy_options[] = [
+					'label' => $taxonomy->label,
+					'value' => $taxonomy->name,
+				];
+			}
+		}
+
+		return $taxonomy_options;
+	}
+
+	/**
+	 * Build the list of published pages offered as options for page-backed
+	 * settings.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	private function get_page_options(): array {
+		$pages = get_pages(
+			[
+				'sort_column' => 'post_title',
+				'sort_order'  => 'ASC',
+			]
+		);
+
+		$page_options = [];
+
+		if ( is_array( $pages ) ) {
+			foreach ( $pages as $page ) {
+				if ( is_object( $page ) && property_exists( $page, 'post_title' ) && property_exists( $page, 'ID' ) ) {
+					$page_options[] = [
+						'label' => $page->post_title . ' (ID: ' . $page->ID . ')',
+						'value' => (string) $page->ID,
+					];
+				}
+			}
+		}
+
+		return $page_options;
 	}
 
 	/**


### PR DESCRIPTION
## Problem

In the redesigned settings screen, the Commerce **Brand** selector showed only **(not set)** with no taxonomies to choose from, even on stores with product brands configured. This was reported by a customer (Blocksy theme + WooCommerce brands) but affects every site: the brand list never loads regardless of theme or brand plugin.

## Root cause

The whole settings UI is now a single React shell, localized once by `GeneralOptionsPage::localize_script()`. Its `gtmkitSettings` payload omitted `taxonomyOptions` and `pageOptions`. The Brand field reads its options from `taxonomyOptions`, so `SettingsService.getTaxonomyOptions()` returned `[]` and the dropdown rendered just the "(not set)" placeholder. The page-backed Commerce field (sourced from `pageOptions`) was silently broken the same way.

The build logic still existed only in the now-orphaned `IntegrationsOptionsPage`, which no longer renders the Commerce UI.

## Fix

Build both lists in `GeneralOptionsPage` and add them to the localized payload, so every settings page (including Commerce) receives them. Taxonomy enumeration is unchanged from the original (`public`, `show_ui`, non-built-in taxonomies), so any brand taxonomy — WooCommerce native `product_brand`, attribute-based, or third-party — is detected automatically.

PHP-only change; the React side already consumes these keys.

## Test plan

- [x] Commerce → Basic Settings: the **Brand** selector lists product brand taxonomies (e.g. WooCommerce's native Brands, `pa_brand`) and a selection saves and persists.
- [x] The page-backed Commerce option lists published pages.

