### PR TITLE
Release 2.16.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** GTM Kit ***
 
-Unreleased
+2026-06-23 - version 2.16.1
+* Add: The Event Deferral setting now warns when it is switched on while Consent Mode is off, because deferred events have no consent signal to wait on and never release in that state.
 * Fix: The Commerce "Brand" selector now lists your product brand taxonomies again, instead of showing only "(not set)". The redesigned settings screen stopped loading the taxonomy and page lists, so the Brand selector (and other taxonomy- or page-based options) appeared empty regardless of how brands were configured.
 
 2026-06-23 - version 2.16.0

--- a/gtm-kit.php
+++ b/gtm-kit.php
@@ -3,7 +3,7 @@
  * GTM Kit Plugin
  *
  * Plugin Name: GTM Kit
- * Version:     2.16.0
+ * Version:     2.16.1
  * Plugin URI:  https://gtmkit.com/
  * Description: Google Tag Manager implementation focusing on flexibility and pagespeed.
  * Author:      GTM Kit
@@ -27,7 +27,7 @@ if ( ! function_exists( 'add_filter' ) ) {
 	exit();
 }
 
-const GTMKIT_VERSION = '2.16.0';
+const GTMKIT_VERSION = '2.16.1';
 
 if ( ! defined( 'GTMKIT_FILE' ) ) {
 	define( 'GTMKIT_FILE', __FILE__ );

--- a/languages/gtm-kit.pot
+++ b/languages/gtm-kit.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv3.
 msgid ""
 msgstr ""
-"Project-Id-Version: GTM Kit 2.16.0\n"
+"Project-Id-Version: GTM Kit 2.16.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/gtm-kit\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-19T13:06:18+00:00\n"
+"POT-Creation-Date: 2026-06-23T09:18:47+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.9.0\n"
 "X-Domain: gtm-kit\n"
@@ -44,23 +44,23 @@ msgstr ""
 msgid "Required by %s"
 msgstr ""
 
-#: src/Admin/AbstractOptionsPage.php:229
+#: src/Admin/AbstractOptionsPage.php:250
 #: src/Admin/SetupWizard.php:213
 msgid "Whoops, something's not working."
 msgstr ""
 
-#: src/Admin/AbstractOptionsPage.php:232
+#: src/Admin/AbstractOptionsPage.php:253
 #: src/Admin/SetupWizard.php:216
 msgid "It looks like something is preventing JavaScript from loading on your website. GTM Kit requires JavaScript in order to give you the best possible experience."
 msgstr ""
 
-#: src/Admin/AbstractOptionsPage.php:237
+#: src/Admin/AbstractOptionsPage.php:258
 #: src/Admin/SetupWizard.php:164
 #: src/Admin/SetupWizard.php:221
 msgid "Go back to the Dashboard"
 msgstr ""
 
-#: src/Admin/AbstractOptionsPage.php:276
+#: src/Admin/AbstractOptionsPage.php:297
 msgid "The plugin is installed and activated"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gtm-kit",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gtm-kit",
-      "version": "2.16.0",
+      "version": "2.16.1",
       "dependencies": {
         "@wordpress/api-fetch": "^7.33.1",
         "@wordpress/components": "^30.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtm-kit",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "Development files for the GTM Kit",
   "author": "GTM Kit",
   "keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://github.com/tlamedia/gtm-kit
 Tags: google tag manager, gtm, woocommerce, analytics, ga4
 Requires at least: 6.8
 Tested up to: 7.0
-Stable tag: 2.16.0
+Stable tag: 2.16.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -101,7 +101,14 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= Unreleased =
+= 2.16.1 =
+
+Release date: 2026-06-23
+
+Find out about what's new in our [our release post](https://gtmkit.com/changelog/gtm-kit-2-16/).
+
+#### New:
+* The Event Deferral setting now warns when it is switched on while Consent Mode is off, because deferred events have no consent signal to wait on and never release in that state.
 
 #### Bugfixes:
 * The Commerce "Brand" selector now lists your product brand taxonomies again, instead of showing only "(not set)". The redesigned settings screen stopped loading the taxonomy and page lists, so the Brand selector (and other taxonomy- or page-based options) appeared empty regardless of how brands were configured.
@@ -125,7 +132,7 @@ Find out about what's new in our [our release post](https://gtmkit.com/changelog
 
 Release date: 2026-06-12
 
-Find out about what's new in our [our release post](https://gtmkit.com/gtm-kit-2-15/).
+Find out about what's new in our [our release post](https://gtmkit.com/changelog/gtm-kit-2-15/).
 
 #### Bugfixes:
 * Security hardening: Links served to the settings interface from remote content (upgrade offers, templates, tutorials) and notifications are now validated before they are used for navigation.
@@ -137,7 +144,7 @@ Find out about what's new in our [our release post](https://gtmkit.com/gtm-kit-2
 
 Release date: 2026-06-03
 
-A maintenance fix for the 2.14 line; see the [2.14 release post](https://gtmkit.com/gtm-kit-2-14/) for what 2.14 introduced.
+A maintenance fix for the 2.14 line; see the [2.14 release post](https://gtmkit.com/changelog/gtm-kit-2-14/) for what 2.14 introduced.
 
 #### Bugfixes:
 * WooCommerce block tracking now loads on block (FSE) themes where Cart, Checkout, Mini Cart, Product Collection, or Related Products are rendered from block templates and template parts. Previously the block tracking bundle could fail to load on these sites, so block ecommerce events never fired.
@@ -146,7 +153,7 @@ A maintenance fix for the 2.14 line; see the [2.14 release post](https://gtmkit.
 
 Release date: 2026-06-02
 
-Find out about what's new in our [release post](https://gtmkit.com/gtm-kit-2-14/).
+Find out about what's new in our [release post](https://gtmkit.com/changelog/gtm-kit-2-14/).
 
 #### New:
 * New "Engagement events" settings section emits GA4 standard `login`, `sign_up`, `search`, and `generate_lead` events out of the box. Each event has its own toggle and defaults to on, so customers see the events the moment they upgrade.
@@ -166,7 +173,7 @@ Find out about what's new in our [release post](https://gtmkit.com/gtm-kit-2-14/
 
 Release date: 2026-05-26
 
-A maintenance fix for the 2.13 line; see the [2.13 release post](https://gtmkit.com/gtm-kit-2-13/) for what 2.13 introduced.
+A maintenance fix for the 2.13 line; see the [2.13 release post](https://gtmkit.com/changelog/gtm-kit-2-13/) for what 2.13 introduced.
 
 #### Bugfixes:
 * The "Exclude pages from GTM" feature now also holds back the WooCommerce, Contact Form 7, and Easy Digital Downloads tracking scripts on excluded pages. Previously those add-on scripts could still load on an excluded page and fail, because the core GTM Kit runtime they rely on was withheld there.
@@ -175,7 +182,7 @@ A maintenance fix for the 2.13 line; see the [2.13 release post](https://gtmkit.
 
 Release date: 2026-05-26
 
-Find out about what's new in our [release post](https://gtmkit.com/gtm-kit-2-13/).
+Find out about what's new in our [release post](https://gtmkit.com/changelog/gtm-kit-2-13/).
 
 #### New:
 * New "Exclude pages from GTM" section on the Container settings page lets you list URL patterns where GTM Kit should stay off. Useful for third-party checkout iframes, partner-hosted subpages, or in-app webview routes that have their own tracking.
@@ -184,23 +191,6 @@ Find out about what's new in our [release post](https://gtmkit.com/gtm-kit-2-13/
 #### Other:
 * The existing `gtmkit_container_active` filter now receives the actual computed container-active value instead of a hardcoded `true`, so callbacks that return the value through unchanged automatically honor the new URL exclusion.
 * PHP-rendered initial dataLayer content is now emitted through the same client helper, so deferral works the same on full-page-cached and uncached pages.
-
-= 2.12.0 =
-
-Release date: 2026-05-19
-
-Find out about what's new in our [release post](https://gtmkit.com/gtm-kit-2-12/).
-
-#### New:
-* New welcome modal greets fresh installs on their first GTM Kit admin page and links to the documentation. Existing installs are not interrupted.
-* GTM Kit can now surface launch and upgrade announcements from gtmkit.com without a plugin release.
-
-#### Bugfixes:
-* Prevent a fatal error on WooCommerce shop and archive pages when another plugin (e.g. WP Grid Builder) re-runs the product loop without a current product in context. GTM Kit now skips its hidden product-data tag instead of crashing the page.
-* No more "headers already sent" PHP warning when running WP-CLI commands on sites that use the Cookie Keeper option.
-
-#### Other:
-* New `gtmkit_introductions` filter and `Introduction_Interface` contract let add-ons register their own announcement modals through a documented public API.
 
 = Earlier versions =
 For the changelog of earlier versions, please refer to [the changelog on gtmkit.com](https://gtmkit.com/changelog/).


### PR DESCRIPTION
## Summary

Cuts gtm-kit 2.16.1. Headline scope:

- **Fix:** the Commerce **Brand** selector lists product brand taxonomies again instead of showing only "(not set)". The redesigned settings shell stopped localizing the taxonomy and page option lists, so any taxonomy- or page-backed selector rendered empty for all users regardless of brand configuration.
- **Add:** the Event Deferral setting now warns when it is switched on while Consent Mode is off (deferred events have no consent signal to wait on and never release in that state).

Version bump:
- gtm-kit.php — Version header + GTMKIT_VERSION constant
- readme.txt — Stable tag 2.16.1 + canonical = 2.16.1 = block linked to gtmkit.com/changelog/gtm-kit-2-16/
- package.json + package-lock.json — 2.16.1

Translation template: languages/gtm-kit.pot regenerated, Project-Id-Version: GTM Kit 2.16.1 (no new strings; the Event Deferral notice string is included).

Assets rebuilt: assets/admin/settings.* carry the Event Deferral notice; consent-gating shim 969/1024 bytes, size guard green. No other asset delta.

readme.txt changelog pruned to the retention window (dropped the 2.12 block).

## Quality gates
- [x] composer phpstan — 0 errors
- [x] composer phpcs — 0 errors, 0 warnings
- [x] PHPUnit unit — 102/102
- [x] PHPUnit integration — 90 passed, 1 documented skip
- [x] Vitest — 100/100
- [x] Jest (settings app) — 197/197, including the new Event Deferral notice tests
- [x] consent-gating bundle size — 969 / 1024 bytes
- [x] readme.txt changelog retention — bin/check-readme-changelog.sh PASS
- [x] plugintests.com (published 2.16.0) — newest report 2026-06-23 -> ok
- [x] Add-on backward-compat gate — PASS (isolated single-add-on runs; combined-run Woo result is the known Premium duplicate-init false negative)
- [x] Shipped-code review for fatals/serious bugs — clean
